### PR TITLE
Fix EZP-20862: YUI3 JS/CSS files fail to load in non vhost setup

### DIFF
--- a/Resources/public/js/ezyuiconfig.js
+++ b/Resources/public/js/ezyuiconfig.js
@@ -1,1 +1,0 @@
-var YUI3_config = {"base":"\/extension\/ezjscore\/design\/standard\/lib\/yui\/3.9.0\/build\/","combine":false,"modules":{}};

--- a/Resources/views/page_head_script.html.twig
+++ b/Resources/views/page_head_script.html.twig
@@ -1,7 +1,10 @@
 {# TODO:  handle loading JavaScript files from the INI configuration as well as ezjscore #}
 
+<script type="text/javascript">
+var YUI3_config = {base: "{{ asset( 'extension/ezjscore/design/standard/lib/yui/3.9.0/build/' ) }}", modules: {}, combine: false};
+</script>
+
 {% javascripts
-    '@eZDemoBundle/Resources/public/js/ezyuiconfig.js'
     'extension/ezjscore/design/standard/lib/yui/3.9.0/build/yui/yui-min.js'
     'extension/ezjscore/design/standard/javascript/jquery-1.9.1.min.js'
     'extension/ezjscore/design/standard/javascript/jquery-ui-1.10.1.custom.min.js'


### PR DESCRIPTION
JIRA issue: https://jira.ez.no/browse/EZP-20862
# Description

In non virtual host setup, the path of the JS/CSS files build by the YUI3 loader are wrong because of a hardcoded path in ezyuiconfig.js. This patch changes the configuration to be dynamic so that this path is correct in different setups.
# Tests

manual tests
