### PR TITLE
Implement Behat testing on travis for DemoBundle repo

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,41 @@
+language: php
+
+# run tests on php 5.4 only and let unit / integration tests deal with php differences
+php:
+  - 5.4
+
+# list of paths/bundle to execute
+env:
+  - TEST_SUIT="@eZDemoBundle"
+
+# test only master (+ Pull requests)
+branches:
+  only:
+    - master
+
+# Get ezpublish5 repo, set it as build dir & install it's packages
+before_install:
+  - export OLD_TRAVIS_BUILD_DIR="$TRAVIS_BUILD_DIR"
+  - export TRAVIS_BUILD_DIR="$HOME/build/ezpublish-community"
+  - cd "$HOME/build"
+  - git clone --depth 1 https://github.com/ezsystems/ezpublish-community.git
+  - cd ezpublish-community
+  - ./bin/.travis/behat_before_install.sh
+
+# setup requirements for running tests, move our bundle in & run last requirements script
+before_script:
+  - ./bin/.travis/behat_before_script1.sh
+  - rm -fR vendor/ezsystems/demobundle/EzSystems/DemoBundle
+  - mv "$OLD_TRAVIS_BUILD_DIR" vendor/ezsystems/demobundle/EzSystems
+  - ./bin/.travis/behat_before_script2.sh
+
+# execute behat as the script command
+script: "bin/behat $TEST_SUIT"
+
+# disable mail notifications
+notification:
+  email: false
+
+# reduce depth (history) of git checkout
+git:
+  depth: 30


### PR DESCRIPTION
Adds travis functional tests (behat) for DemoBundle, reusing the slightly abstracted scripts in ezpublish-community so they can be tweaked there independently later.
