### PR TITLE
EZP-21532: Added commentsBundle as a dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,8 @@
     "minimum-stability": "dev",
     "require": {
         "php": ">=5.3.3",
-        "ezsystems/ezpublish-kernel": "*"
+        "ezsystems/ezpublish-kernel": "*",
+        "ezsystems/comments-bundle": "*"
     },
     "autoload": {
         "psr-0": {"EzSystems\\DemoBundle": ""}


### PR DESCRIPTION
### Description

In order to migrate the DemoBundle to twig, we need to be able to display comments using the new CommentsBundle.

Link: https://jira.ez.no/browse/EZP-21532
