### PR TITLE
EZP-21532: blog and blog_post using symfony stack

### DIFF
--- a/Controller/DemoController.php
+++ b/Controller/DemoController.php
@@ -10,8 +10,14 @@
 namespace EzSystems\DemoBundle\Controller;
 
 use eZ\Bundle\EzPublishCoreBundle\Controller;
+use eZ\Publish\API\Repository\Values\Content\Location;
+use eZ\Publish\Core\Pagination\Pagerfanta\ContentSearchAdapter;
+use Pagerfanta\Pagerfanta;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
+use eZ\Publish\API\Repository\Values\Content\Query;
+use eZ\Publish\API\Repository\Values\Content\Query\Criterion;
+use eZ\Publish\API\Repository\Values\Content\Query\SortClause;
 
 class DemoController extends Controller
 {
@@ -71,4 +77,163 @@ class DemoController extends Controller
             $response
         );
     }
+
+    /**
+     * Displays the list of blog_post
+     * Note: This is a fully customized controller action, it will generate the response and call
+     *       the view. Since it is not calling the ViewControler we don't need to match a specific
+     *       method signature.
+     *
+     * @param int $locationId of a blog
+     * @return \Symfony\Component\HttpFoundation\Response
+     */
+    public function listBlogPostsAction( $locationId )
+    {
+        $response = new Response();
+
+        // Setting default cache configuration (you can override it in you siteaccess config)
+        $response->setSharedMaxAge( $this->getConfigResolver()->getParameter( 'content.default_ttl' ) );
+
+        // Make the response location cache aware for the reverse proxy
+        $response->headers->set( 'X-Location-Id', $locationId );
+        $response->setVary( 'X-User-Hash' );
+
+        $viewParameters = $this->getRequest()->attributes->get( 'viewParameters' );
+
+        // TODO keyword search is not implemented in the public API yet, so we forward to a legacy view
+        if ( !empty( $viewParameters['tag'] ) )
+        {
+            $tag = $viewParameters['tag'];
+
+            return $this->redirect(
+                $this->generateUrl(
+                    'ez_legacy',
+                    array( 'module_uri' => '/content/keyword/' . $tag )
+                )
+            );
+        }
+
+        // Getting location and content from ezpublish dedicated services
+        $repository = $this->getRepository();
+        $location = $repository->getLocationService()->loadLocation( $locationId );
+        $content = $repository
+            ->getContentService()
+            ->loadContentByContentInfo( $location->getContentInfo() );
+
+        // Using the criteria helper (a demobundle custom service) to generate our query's criteria.
+        // This is a good practice in order to have less code in your controller.
+        $criteria = $this->get( 'ezdemo.criteria_helper' )->generateListBlogPostCriterion(
+            $location, $viewParameters
+        );
+
+        // Generating query
+        $query = new Query();
+        $query->criterion = $criteria;
+        $query->sortClauses = array(
+            new SortClause\Field( 'blog_post', 'publication_date', Query::SORT_DESC )
+        );
+
+        // Initialize pagination.
+        $pager = new Pagerfanta(
+            new ContentSearchAdapter( $query, $this->getRepository()->getSearchService() )
+        );
+        $pager->setMaxPerPage( $this->container->getParameter( 'ezdemo.blog.blog_post_list.limit' ) );
+        $pager->setCurrentPage( $this->getRequest()->get( 'page', 1 ) );
+
+        return $this->render(
+            'eZDemoBundle:full:blog.html.twig',
+            array(
+                'location' => $location,
+                'content' => $content,
+                'pagerBlog' => $pager
+            ),
+            $response
+        );
+    }
+
+    /**
+     * Action used to display a blog_post
+     *  - Adds the content's author to the response.
+     * Note: This is a partly customized controller action. It is executed just before the original
+     *       Viewcontroller's viewLocation method. To be able to do that, we need to implement it's
+     *       full signature.
+     *
+     * @param $locationId
+     * @param $viewType
+     * @param bool $layout
+     * @param array $params
+     * @return \Symfony\Component\HttpFoundation\Response
+     */
+    public function showBlogPostAction( $locationId, $viewType, $layout = false, array $params = array() )
+    {
+        // We need the author, whatever the view type is.
+        $repository = $this->getRepository();
+        $location = $repository->getLocationService()->loadLocation( $locationId );
+        $author = $repository->getUserService()->loadUser( $location->getContentInfo()->ownerId );
+
+        // TODO once the keyword service is available, load the number of keyword for each keyword
+
+        // Delegate view rendering to the original ViewController
+        // (makes it possible to continue using defined template rules)
+        // We just add "author" to the list of variables exposed to the final template
+        return $this->get( 'ez_content' )->viewLocation(
+            $locationId,
+            $viewType,
+            $layout,
+            array( 'author' => $author )
+        );
+    }
+
+    /**
+     * Displays content having similar tags as the given location
+     *
+     * @param \eZ\Publish\API\Repository\Values\Content\Location $location
+     * @return \Symfony\Component\HttpFoundation\Response
+     */
+    public function viewTagRelatedContentAction( Location $location )
+    {
+        // TODO once the keyword service is available replace this subrequest by a full symfony one
+
+        return $this->render(
+            'eZDemoBundle:parts:related_content.html.twig',
+            array( 'location' => $location )
+        );
+    }
+
+    /**
+     * Displays description, tagcloud, tags, ezarchive and calendar
+     * of the parent's of a given location
+     *
+     * @param \eZ\Publish\API\Repository\Values\Content\Location $location
+     * @return \Symfony\Component\HttpFoundation\Response
+     */
+    public function viewParentExtraInfoAction( Location $location )
+    {
+        $repository = $this->getRepository();
+        $parentLocation = $repository->getLocationService()->loadLocation( $location->parentLocationId );
+
+        // TODO once the keyword service is available replace part this subrequest by a full symfony one
+
+        return $this->render(
+            'eZDemoBundle:parts/blog:extra_info.html.twig',
+            array( 'location' => $parentLocation )
+        );
+    }
+
+    /**
+     * Displays description, tagcloud, tags, ezarchive and calendar for a given location
+     *
+     * @param \eZ\Publish\API\Repository\Values\Content\Location $location
+     * @return \Symfony\Component\HttpFoundation\Response
+     */
+    public function viewExtraInfoAction( Location $location )
+    {
+        // TODO once the keyword service is available replace part this subrequest by a full symfony one
+
+        return $this->render(
+            'eZDemoBundle:parts/blog:extra_info.html.twig',
+            array( 'location' => $location )
+        );
+    }
+
 }

--- a/Resources/config/default_settings.yml
+++ b/Resources/config/default_settings.yml
@@ -9,3 +9,5 @@ parameters:
     ezdemo.footer.content_id: 58
     # ContentType identifiers we want to have in "latest content" part of the footer.
     ezdemo.footer.latest_content.content_types: [article]
+    # Number of blog_posts displayed per page in the blog view
+    ezdemo.blog.blog_post_list.limit: 10

--- a/Resources/config/ezdemo.yml
+++ b/Resources/config/ezdemo.yml
@@ -1,1 +1,32 @@
+siteaccess:
+    groups:
+        ezdemo_frontend_group:
+            - ezdemo_site
+            - eng
+
+system:
+    ezdemo_frontend_group:
+        location_view:
+            full:
+                # There are two ways to add extra information to your response using a custom controller
+                blog:
+                    # Fully customized, handling everything yourself
+                    controller: "eZDemoBundle:Demo:listBlogPosts"
+                    match:
+                        Identifier\ContentType: [blog]
+                blog_post:
+                    # Enriched controller, only adding extra parameters
+                    controller: "eZDemoBundle:Demo:showBlogPost"
+                    # Overriding the template used by the default viewLocation
+                    template: "eZDemoBundle:full:blog_post.html.twig"
+                    match:
+                        Identifier\ContentType: [blog_post]
+            line:
+                blog_post:
+                    controller: "eZDemoBundle:Demo:showBlogPost"
+                    template: "eZDemoBundle:line:blog_post.html.twig"
+                    match:
+                        Identifier\ContentType: [blog_post]
+        field_templates:
+            - {template: "eZDemoBundle::content_fields.html.twig", priority: 10}
 

--- a/Resources/public/css/bootstrap.css
+++ b/Resources/public/css/bootstrap.css
@@ -922,8 +922,8 @@ aside > .content-view-aside:last-child > article:last-child:after {
 .content-view-embed .attribute-header h6 {
   border-bottom: 1px solid #ebebeb;
 }
-.content-view-embed .attribute-header  + div,
-.content-view-embed .attribute-header  + form {
+.content-view-embed .attribute-header + div,
+.content-view-embed .attribute-header + form {
   background-color: #fbfbfb;
   background-image: -moz-linear-gradient(top, #f9f9f9, #ffffff);
   background-image: -ms-linear-gradient(top, #f9f9f9, #ffffff);
@@ -934,7 +934,7 @@ aside > .content-view-aside:last-child > article:last-child:after {
   background-repeat: repeat-x;
   filter: progid:DXImageTransform.Microsoft.gradient(startColorstr='#f9f9f9', endColorstr='#ffffff', GradientType=0);
 }
-.content-view-embed .attribute-header  + form {
+.content-view-embed .attribute-header + form {
   padding-top: 10px;
 }
 .attribute-header + .comment,
@@ -3050,7 +3050,6 @@ table .span12 {
   filter: progid:DXImageTransform.Microsoft.gradient(startColorstr='#ffffff', endColorstr='#e6e6e6', GradientType=0);
   border-color: #e6e6e6 #e6e6e6 #bfbfbf;
   border-color: rgba(0, 0, 0, 0.1) rgba(0, 0, 0, 0.1) rgba(0, 0, 0, 0.25);
-  filter: progid:DXImageTransform.Microsoft.gradient(enabled = false);
   border: 1px solid #ccc;
   border-bottom-color: #bbb;
   -webkit-border-radius: 4px;
@@ -4351,6 +4350,9 @@ input[type="submit"].btn.small {
 }
 .pagination-right {
   text-align: right;
+}
+.pagination li:before {
+  content: none;
 }
 .pager {
   margin-left: 0;

--- a/Resources/public/less/pagination.less
+++ b/Resources/public/less/pagination.less
@@ -53,3 +53,7 @@
 .pagination-right {
   text-align: right;
 }
+
+.pagination li:before {
+  content: none;
+}

--- a/Resources/views/content_fields.html.twig
+++ b/Resources/views/content_fields.html.twig
@@ -1,0 +1,19 @@
+{% extends 'EzPublishCoreBundle::content_fields.html.twig' %}
+
+{% block ezkeyword_field %}
+    {% spaceless %}
+        {% if field.value.values|length() > 0 %}
+            <ul {{ block( 'field_attributes' ) }} >
+                {% for keyword in field.value.values %}
+                <li>
+                    {# Forwarding on legacy #}
+                    <a href="{{ path( 'ez_legacy', {'module_uri': 'content/keyword/' ~ keyword} ) }}">
+                        <span class="tag-title">{{ keyword }}</span>
+                        {# TODO depends on EZP-21472 <span class="tag-amount">{fetch( 'content', 'keyword_count', hash( 'alphabet', $keyword ) )}</span> #}
+                    </a>
+                </li>
+                {% endfor %}
+            </ul>
+        {% endif %}
+    {% endspaceless %}
+{% endblock %}

--- a/Resources/views/full/blog.html.twig
+++ b/Resources/views/full/blog.html.twig
@@ -1,0 +1,47 @@
+{% extends "eZDemoBundle::pagelayout.html.twig" %}
+
+{% block content %}
+    <section class="content-view-full">
+        <div class="class-blog">
+            <div class="row">
+                <div class="span8">
+                    {% if pagerBlog|length() > 0 %}
+                        <section class="content-view-children">
+                            {% for post in pagerBlog %}
+                                {# Displaying blog_post elements calling the view line #}
+                                {{ render_esi( controller( 'ez_content:viewLocation', {'locationId': post.contentInfo.mainLocationId, 'viewType': 'line'} ) ) }}
+                            {% endfor %}
+                        </section>
+
+                        {# Pagination is displayed only if needed (number of posts > limit) #}
+                        {% if pagerBlog.haveToPaginate() %}
+                            <div class="pagination-centered">
+                                {{ pagerfanta( pagerBlog, 'twitter_bootstrap_translated', {'routeName': location} ) }}
+                            </div>
+                        {% endif %}
+
+                    {% endif %}
+                </div>
+                <div class="span4">
+                    <aside>
+                        <section class="content-view-aside">
+
+                            {% if not ez_is_field_empty( content, 'description' ) %}
+                                <h2>{{ "Description"|trans }}</h2>
+                                <article>
+                                    <div class="attribute-description">
+                                        {{ ez_render_field( content, 'description' ) }}
+                                    </div>
+                                </article>
+                            {% endif %}
+
+                            {# This is a call to a subrequest calling legacy code #}
+                            {{ render( controller( 'eZDemoBundle:Demo:viewExtraInfo', {'location': location} ) ) }}
+
+                        </section>
+                    </aside>
+                </div>
+            </div>
+        </div>
+    </section>
+{% endblock %}

--- a/Resources/views/full/blog_post.html.twig
+++ b/Resources/views/full/blog_post.html.twig
@@ -1,0 +1,47 @@
+{% extends noLayout ? viewbaseLayout : "eZDemoBundle::pagelayout.html.twig" %}
+
+{% block content %}
+    <section class="content-view-full">
+        <div class="class-blog-post">
+            <div class="row">
+                <div class="span8">
+                    <div class="attribute-header">
+                        <h1>{{ ez_render_field( content, "title" ) }}</h1>
+                    </div>
+
+                    <div class="attribute-byline">
+                        <span class="date">
+                            {{ location.contentInfo.publishedDate|localizeddate( 'short', 'short', app.request.locale ) }}
+                        </span>
+
+                        <span class="author">{{ author.contentInfo.name }}</span>
+                    </div>
+
+                    <div class="attribute-body float-break">
+                        {{ ez_render_field( content, 'body' ) }}
+                    </div>
+
+                    <div class="attribute-tags">
+                        {{ ez_render_field( content, 'tags', {'attr': {'class' : 'tags-wrapper'}} ) }}
+                    </div>
+
+                    <div class="attribute-comments">
+                        {{ ez_comments_render_content( content.contentInfo ) }}
+                    </div>
+
+                    {# This is a call to a subrequest calling legacy code #}
+                    {{ render( controller( 'eZDemoBundle:Demo:viewTagRelatedContent', {'location': location} ) ) }}
+
+                </div>
+
+                <div class="span4">
+                    <aside>
+                        <section class="content-view-aside">
+                            {{ render( controller( 'eZDemoBundle:Demo:viewParentExtraInfo', {'location': location} ) ) }}
+                        </section>
+                    </aside>
+                </div>
+            </div>
+        </div>
+    </section>
+{% endblock %}

--- a/Resources/views/line/blog_post.html.twig
+++ b/Resources/views/line/blog_post.html.twig
@@ -1,0 +1,47 @@
+{# In order to use blocks and override ez_render_field's template within this file,
+ # we need to extend from another template and surround our content with a block.
+ #}
+{% extends viewbaseLayout %}
+
+{% block content %}
+<div class="content-view-line">
+    <article class="class-blog-post">
+
+        <div class="attribute-header">
+            {# using ez_field_value to display the title: since it returns an object the __toString method will be called to display the value #}
+            <h2><a href={{ path( location ) }} title="{{ ez_field_value( content, 'title' ) }}">{{ ez_render_field( content, 'title' ) }}</a></h2>
+        </div>
+
+
+        <div class="attribute-byline with-comments">
+            <span class="date">{{ location.contentInfo.publishedDate|localizeddate( 'short', 'short', app.request.locale )}}</span>
+            <span class="author">{{ author.contentInfo.name }}</span>
+
+            <span class="tags"> {{ "Tags:"|trans }}
+                {# _self is used to lookup the override template within this file #}
+                {{ ez_render_field( content, 'tags' , { 'template': _self } ) }}
+            </span>
+        </div>
+
+        <div class="attribute-body">
+            {{ ez_render_field( content, 'body' ) }}
+        </div>
+
+    </article>
+</div>
+{% endblock %}
+
+{# This block is called above as a parameter (using _self) in ez_render_field in order to override
+ # the default template.
+ #}
+{% block ezkeyword_field %}
+    {% spaceless %}
+        {% if field.value.values|length() > 0 %}
+            {% for keyword in field.value.values %}
+                {# Forwarding on legacy #}
+                <a href="{{ path( 'ez_legacy', {'module_uri': 'content/keyword/' ~ keyword} ) }}" title="{{ keyword }}">{{ keyword }}</a>
+                {% if not loop.last %},{% endif %}
+            {% endfor %}
+        {% endif %}
+    {% endspaceless %}
+{% endblock %}

--- a/Resources/views/parts/blog/extra_info.html.twig
+++ b/Resources/views/parts/blog/extra_info.html.twig
@@ -1,0 +1,6 @@
+{# Including a legacy template with the parameter: location (called a Node in legacy).
+ # This is an easy way to use legacy code inside a twig template.
+ # You can look at the DemoController calling this template to have a good example on own to sandbox
+ # a legacy feature inside a controller using a subrequest.
+ #}
+{% include "design:parts/blog/extra_info.tpl" with {"used_node": location } %}

--- a/Resources/views/parts/related_content.html.twig
+++ b/Resources/views/parts/related_content.html.twig
@@ -1,0 +1,6 @@
+{# Including a legacy template with the parameter: location (called a Node in legacy).
+ # This is an easy way to use legacy code inside a twig template.
+ # You can look at the DemoController calling this template to have a good example on own to sandbox
+ # a legacy feature inside a controller using a subrequest.
+ #}
+{% include "design:parts/related_content.tpl" with {"node": location } %}


### PR DESCRIPTION
Link to the issue: https://jira.ez.no/browse/EZP-21532
### Description

We want to migrate the demo bundle to use the symfony stack as much as possible. I started by migrating the blog and blog_post pages.

There is some TODO left, because we do not have a keyword service (or API) yet. I still managed to have most of it working using legacy callbacks or modifying the expected result.
### Test

Manuel tests
### TODO
- [x] Apply first round of suggestion from the review
- [x] Refactor the list blog action
- [x] Make sure there is enough comments for new comers to understand the code.
- [ ] Create a dedicated (sub) Jira issue for the blog and blog_post
