### PR TITLE
Fix EZP-21843: Priority order not working on menu

### DIFF
--- a/Helper/MenuHelper.php
+++ b/Helper/MenuHelper.php
@@ -63,7 +63,7 @@ class MenuHelper
         $query = new Query(
             array(
                 'criterion' => new Criterion\LogicalAnd( $criteria ),
-                'sortClauses' => array( new SortClause\DatePublished( Query::SORT_DESC ) )
+                'sortClauses' => array( new SortClause\LocationPriority( Query::SORT_ASC ) )
             )
         );
         $query->limit = $this->defaultMenuLimit;


### PR DESCRIPTION
This PR resolves issue https://jira.ez.no/browse/EZP-21843

Changed menu items sort from publication date descending to Location priority ascending.
