### PR TITLE
EZP-22301: Added shortname for disqus demo account

### DIFF
--- a/DependencyInjection/eZDemoExtension.php
+++ b/DependencyInjection/eZDemoExtension.php
@@ -49,5 +49,8 @@ class eZDemoExtension extends Extension implements PrependExtensionInterface
 
         $ezpageConfig = Yaml::parse( __DIR__ . '/../Resources/config/ezpage.yml' );
         $container->prependExtensionConfig( 'ezpublish', $ezpageConfig );
+
+        $ezCommentsConfig = Yaml::parse( __DIR__ . '/../Resources/config/ezcomments.yml' );
+        $container->prependExtensionConfig( 'ez_comments', $ezCommentsConfig );
     }
 }

--- a/Resources/config/ezcomments.yml
+++ b/Resources/config/ezcomments.yml
@@ -1,0 +1,14 @@
+system:
+    ezdemo_site_group:
+        default_provider: no_comments
+        disqus:
+            shortname: ezpublishplatformdemo
+        content_comments:
+            blog_post:
+                enabled: true
+                provider: disqus
+                match:
+                    Identifier\ContentType:
+                        - article
+                        - blog_post
+

--- a/Resources/config/ezdemo.yml
+++ b/Resources/config/ezdemo.yml
@@ -2,6 +2,7 @@ siteaccess:
     groups:
         ezdemo_frontend_group:
             - ezdemo_site
+            - ezdemo_site_user
             - eng
             - fre
 


### PR DESCRIPTION
See http://jira.ez.no/browse/EZP-22301

Enables disqus on articles and blog_post content types, using a default `ezpublishplatformdemo` shortname.  Every ezdemo instance will show the same comments on identical content elements (based on content id).
