### PR TITLE
EZP-22193: Make the website toolbar available from a twig pagelayout

### DIFF
--- a/Resources/views/page_head_style.html.twig
+++ b/Resources/views/page_head_style.html.twig
@@ -6,3 +6,7 @@
 %}
     <link rel="stylesheet" type="text/css" href="{{ asset_url }}"/>
 {% endstylesheets %}
+
+<style type="text/css">
+    @import url("{{ asset('extension/ezwt/design/standard/stylesheets/websitetoolbar.css') }}");
+</style>

--- a/Resources/views/pagelayout.html.twig
+++ b/Resources/views/pagelayout.html.twig
@@ -14,6 +14,9 @@
 </head>
 <body>
 <!-- Complete page area: START -->
+{% if location is defined %}
+    {{ render( controller( "ezpublish_legacy.website_toolbar.controller:websiteToolbarAction", { 'locationId': location.id} ) ) }}
+{% endif %}
 <div id="page" class="">
     <!-- Header area: START -->
     {% block header %}


### PR DESCRIPTION
> JIRA issue: http://jira.ez.no/browse/EZP-22193
> Requires ezsystems/ezpublish-kernel#755

Uses a new controller (`ezpublish_legacy.website_toolbar.controller`) that renders the legacy websitetoolbar template.
### Tasks
- [x] Load `websitetoolbar.css` without using assetic (to work around relative asset path issues)
