### PR TITLE
EZP-21846: Contact form using symfony

### DIFF
--- a/Controller/FeedbackFormController.php
+++ b/Controller/FeedbackFormController.php
@@ -1,0 +1,72 @@
+<?php
+/**
+ * File containing the FeedbackController class.
+ *
+ * @copyright Copyright (C) 1999-2014 eZ Systems AS. All rights reserved.
+ * @license http://www.gnu.org/licenses/gpl-2.0.txt GNU General Public License v2
+ * @version //autogentag//
+ */
+
+namespace EzSystems\DemoBundle\Controller;
+
+use eZ\Bundle\EzPublishCoreBundle\Controller;
+use EzSystems\DemoBundle\Entity\Feedback;
+use EzSystems\DemoBundle\Form\Type\FeedbackType;
+use EzSystems\DemoBundle\Helper\EmailHelper;
+
+class FeedbackFormController extends Controller
+{
+    /**
+     * Displays and manages the feedback form.
+     *
+     * The signature of this method follows the one from the default view controller.
+     * @param $locationId
+     * @param $viewType
+     * @param bool $layout
+     * @param array $params
+     *
+     * @return mixed
+     */
+    public function showFeedbackFormAction( $locationId, $viewType, $layout = false, array $params = array() )
+    {
+        // Creating a form using Symfony's form component
+        $feedback = new Feedback();
+        $form = $this->createForm( $this->get( 'ezdemo.form.type.feedback' ), $feedback );
+        $request = $this->getRequest();
+
+        if ( $request->isMethod( 'POST' ) )
+        {
+            $form->handleRequest( $request );
+
+            if ( $form->isValid() )
+            {
+                /** @var EmailHelper $emailHelper */
+                $emailHelper = $this->get( 'ezdemo.email_helper' );
+                $emailHelper->sendFeebackMessage(
+                    $feedback,
+                    $this->container->getParameter( 'ezdemo.feedback_form.email_from' ),
+                    $this->container->getParameter( 'ezdemo.feedback_form.email_to' )
+                );
+
+                // Adding the confirmation flash message to the session
+                $this->get( 'session' )->getFlashBag()->add(
+                    'notice',
+                    $this->get( 'translator' )->trans( 'Thank you for your message, we will get back to you as soon as possible.' )
+                );
+
+                $this->redirect(
+                    $this->generateUrl(
+                        $this->getRepository()->getLocationService()->loadLocation( $locationId )
+                    )
+                );
+            }
+        }
+
+        return $this->get( 'ez_content' )->viewLocation(
+            $locationId,
+            $viewType,
+            $layout,
+            array( 'form' => $form->createView() )
+        );
+    }
+}

--- a/Entity/Feedback.php
+++ b/Entity/Feedback.php
@@ -1,0 +1,53 @@
+<?php
+/**
+ * File containing the Feedback class.
+ *
+ * @copyright Copyright (C) 1999-2014 eZ Systems AS. All rights reserved.
+ * @license http://www.gnu.org/licenses/gpl-2.0.txt GNU General Public License v2
+ * @version //autogentag//
+ */
+
+namespace EzSystems\DemoBundle\Entity;
+
+use Symfony\Component\Validator\Constraints as Assert;
+
+class Feedback
+{
+    /**
+     * @Assert\NotBlank()
+     * @Assert\Length( min = 1, max = 255, maxMessage = "feedback.max_size.255" )
+     */
+    public $firstName;
+
+    /**
+     * @Assert\NotBlank()
+     * @Assert\Length( min = 1, max = 255, maxMessage = "feedback.max_size.255" )
+     */
+    public $lastName;
+
+    /**
+     * @Assert\NotBlank()
+     * @Assert\Length( min = 1, max = 255, maxMessage = "feedback.max_size.255" )
+     * @Assert\Email
+     */
+    public $email;
+
+    /**
+     * @Assert\NotBlank()
+     * @Assert\Length( min = 1, max = 255, maxMessage = "feedback.max_size.255" )
+     */
+    public $subject;
+
+    /**
+     * @Assert\NotBlank()
+     * @Assert\Length( min = 1, max = 255, maxMessage = "feedback.max_size.255" )
+     */
+    public $country;
+
+    /**
+     * @Assert\NotBlank()
+     * @Assert\Length( min = 1, max = 2000, maxMessage = "feedback.max_size.2000" )
+     */
+    public $message;
+
+}

--- a/Form/Type/FeedbackType.php
+++ b/Form/Type/FeedbackType.php
@@ -1,0 +1,39 @@
+<?php
+/**
+ * File containing the FeedbackType class.
+ *
+ * @copyright Copyright (C) 1999-2014 eZ Systems AS. All rights reserved.
+ * @license http://www.gnu.org/licenses/gpl-2.0.txt GNU General Public License v2
+ * @version //autogentag//
+ */
+
+namespace EzSystems\DemoBundle\Form\Type;
+
+use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\FormBuilderInterface;
+use Symfony\Component\OptionsResolver\OptionsResolverInterface;
+
+class FeedbackType extends AbstractType
+{
+    public function buildForm( FormBuilderInterface $builder, array $options )
+    {
+        $builder
+            ->add( 'firstName', 'text' )
+            ->add( 'lastName', 'text' )
+            ->add( 'email', 'email' )
+            ->add( 'subject', 'text' )
+            ->add( 'country', 'country' )
+            ->add( 'message', 'textarea' )
+            ->add( 'save', 'submit' );
+    }
+
+    public function getName()
+    {
+        return 'ezdemo_feedback';
+    }
+
+    public function setDefaultOptions( OptionsResolverInterface $resolver )
+    {
+        $resolver->setDefaults( array( 'data_class' => 'EzSystems\DemoBundle\Entity\Feedback' ) );
+    }
+}

--- a/Helper/EmailHelper.php
+++ b/Helper/EmailHelper.php
@@ -1,0 +1,84 @@
+<?php
+/**
+ * File containing the EmailHelper class.
+ *
+ * @copyright Copyright (C) 1999-2014 eZ Systems AS. All rights reserved.
+ * @license http://www.gnu.org/licenses/gpl-2.0.txt GNU General Public License v2
+ * @version //autogentag//
+ */
+
+namespace EzSystems\DemoBundle\Helper;
+
+use EzSystems\DemoBundle\Entity\Feedback;
+use Swift_Mailer;
+use Swift_Message;
+use Symfony\Component\Templating\EngineInterface;
+use Symfony\Component\Translation\TranslatorInterface;
+
+/**
+ * Helper for emails
+ *
+ * This class is meant to fulfill email related needs of the DemoBundle.
+ *
+ * For example, it contains a method that sends by email the content of a Feedback form.
+ */
+class EmailHelper
+{
+    /**
+     * @var \Symfony\Component\Translation\TranslatorInterface
+     */
+    private $translator;
+
+    /**
+     * @var \Symfony\Component\Templating\EngineInterface
+     */
+    private $templating;
+
+    /**
+     * @var \Swift_Mailer
+     */
+    private $mailer;
+
+    public function __construct(
+        TranslatorInterface $translator,
+        EngineInterface $templating,
+        Swift_Mailer $mailer
+    )
+    {
+        $this->translator = $translator;
+        $this->templating = $templating;
+        $this->mailer = $mailer;
+    }
+
+    /**
+     * Sends an email based on a feedback form.
+     *
+     * @param \EzSystems\DemoBundle\Entity\Feedback $feedback
+     * @param string $feedbackEmailFrom  Email address sending feedback form
+     * @param string $feedbackEmailTo Email address feedback forms will be sent to
+     */
+    public function sendFeebackMessage( Feedback $feedback, $feedbackEmailFrom, $feedbackEmailTo )
+    {
+        $message = Swift_Message::newInstance();
+
+        $message->setSubject( $this->translator->trans( 'eZ Demobundle Feedback form' ) )
+            ->setFrom( $feedbackEmailFrom )
+            ->setTo( $feedbackEmailTo )
+            ->setBody(
+                // Using template engine to generate the message based on a template
+                $this->templating->render(
+                    'eZDemoBundle:email:feedback_form.txt.twig',
+                    array(
+                        'firstname' => $feedback->firstName,
+                        'lastname' => $feedback->lastName,
+                        'email' => $feedback->email,
+                        'subject' => $feedback->subject,
+                        'country' => $feedback->country,
+                        'message' => $feedback->message
+                    )
+                )
+            );
+
+        $this->mailer->send( $message );
+    }
+}

--- a/Resources/config/default_settings.yml
+++ b/Resources/config/default_settings.yml
@@ -26,3 +26,10 @@ parameters:
 
     ## Cache settings
     ezdemo.cache.feed_reader_ttl: 3600
+
+    ## Feedback Form
+    # Reminder: You can override these settings in config_dev.yml or config_prod.yml for debug or prod
+    # Email address to send contact form emails to
+    ezdemo.feedback_form.email_to: root@localhost
+    # Email address displayed as sent
+    ezdemo.feedback_form.email_from: noreply@ezdemobundle.test

--- a/Resources/config/ezdemo.yml
+++ b/Resources/config/ezdemo.yml
@@ -43,6 +43,11 @@ system:
                     template: "eZDemoBundle:full:place.html.twig"
                     match:
                         Identifier\ContentType: [place]
+                feedback_form:
+                    controller: "eZDemoBundle:FeedbackForm:showFeedbackForm"
+                    template: "eZDemoBundle:full:feedback_form.html.twig"
+                    match:
+                        Identifier\ContentType: "feedback_form"
 
             line:
                 article:

--- a/Resources/config/services.yml
+++ b/Resources/config/services.yml
@@ -3,6 +3,9 @@ parameters:
     ezdemo.menu_helper.class: EzSystems\DemoBundle\Helper\MenuHelper
     ezdemo.place_helper.class: EzSystems\DemoBundle\Helper\PlaceHelper
     ezdemo.search_helper.class: EzSystems\DemoBundle\Helper\SearchHelper
+    ezdemo.email_helper.class: EzSystems\DemoBundle\Helper\EmailHelper
+    ezdemo.form.type.feedback.class: EzSystems\DemoBundle\Form\Type\FeedbackType
+
     # Default limit that will be applied when retrieving content for menus.
     ezdemo.menu_helper.default_limit: 10
 
@@ -25,5 +28,18 @@ services:
                 - %ezdemo.places.place_list.min%
                 - %ezdemo.places.place_list.max%
 
+    ezdemo.email_helper:
+        class: %ezdemo.email_helper.class%
+        arguments:
+            - @translator
+            - @templating
+            - @mailer
+
     ezdemo.search_helper:
         class: %ezdemo.search_helper.class%
+
+    # Declaring the feedback form as a service
+    ezdemo.form.type.feedback:
+        class: %ezdemo.form.type.feedback.class%
+        tags:
+            - { name: form.type, alias: ezdemo_feedback }

--- a/Resources/public/css/bootstrap.css
+++ b/Resources/public/css/bootstrap.css
@@ -2794,6 +2794,11 @@ select[name="FromVersion"],
 select[name="ToVersion"] {
   width: 60px;
 }
+.form-success {
+  color: #468847;
+  text-align: center;
+  font-weight: bold;
+}
 table {
   max-width: 100%;
   border-collapse: collapse;

--- a/Resources/public/less/forms.less
+++ b/Resources/public/less/forms.less
@@ -579,3 +579,9 @@ select[name="FromVersion"],
 select[name="ToVersion"] {
     width: 60px;
 }
+
+.form-success {
+    color: #468847;
+    text-align: center;
+    font-weight: bold;
+}

--- a/Resources/translations/validators.en.xliff
+++ b/Resources/translations/validators.en.xliff
@@ -1,0 +1,15 @@
+<?xml version="1.0"?>
+<xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">
+    <file source-language="en" datatype="plaintext" original="file.ext">
+        <body>
+            <trans-unit id="1">
+                <source>feedback.max_size.255</source>
+                <target>This field cannot be longer than 255 characters</target>
+            </trans-unit>
+            <trans-unit id="2">
+                <source>feedback.max_size.2000</source>
+                <target>This field cannot be longer than 2000 characters</target>
+            </trans-unit>
+        </body>
+    </file>
+</xliff>

--- a/Resources/views/email/feedback_form.txt.twig
+++ b/Resources/views/email/feedback_form.txt.twig
@@ -1,0 +1,30 @@
+{#
+ Content of the email (sent to an address configured in default_setting.yml) when a user submits a feedback form.
+
+ Expected parameters:
+ - firstname
+ - lastname
+ - email
+ - subject
+ - country
+ - message
+#}
+
+{% trans %}
+Hello,
+A new feedback form has been submited.
+
+Please find the related information:
+
+- First name: %firstname%
+- Last name: %lastname%
+- Email: %email%
+- Subject: %subject%
+- Country: %country%
+- Message:
+"%message%"
+
+
+Best regards,
+The eZ Demobundle Team.
+{% endtrans %}

--- a/Resources/views/full/feedback_form.html.twig
+++ b/Resources/views/full/feedback_form.html.twig
@@ -1,0 +1,99 @@
+{% extends "eZDemoBundle::pagelayout.html.twig" %}
+
+{# Customizing the error message to add a css class since form_errors doesn't accept parameters #}
+{% form_theme form _self %}
+
+{% block form_errors %}
+    {% if errors|length > 0 %}
+        <span class="help-inline">
+            {% for error in errors %}
+                {{ error.message }}
+                {% if not loop.last %},{% endif %}
+            {% endfor %}
+        </span>
+    {% endif %}
+{% endblock form_errors %}
+
+{% block content %}
+
+<section class="content-view-full">
+    <div class="row">
+        <div class="span8">
+
+            <div class="attribute-header">
+                <h1>{{ ez_render_field( content, 'name' ) }}</h1>
+            </div>
+
+            <div class="attribute-short">
+                {{ ez_render_field( content, 'description' ) }}
+            </div>
+
+            {% for flashMessage in app.session.flashbag.get('notice') %}
+                <p class="form-success">
+                    {{ flashMessage }}
+                </p>
+
+            {% else %}
+                {{ form_start( form ) }}
+
+                <div class="row">
+                    {{ form_errors( form ) }}
+                </div>
+
+                <div class="control-group {% if form.firstName.vars.errors %}error{% endif %}">
+                    {{ form_label( form.firstName, 'First Name'|trans,  { 'attr': {'class': 'control-label'}} ) }}
+                    <div class="controls">
+                        {{ form_widget( form.firstName, { 'attr': {'class': 'span4'}} ) }}
+                        {{ form_errors( form.firstName ) }}
+                    </div>
+                </div>
+
+                <div class="control-group {% if form.lastName.vars.errors %}error{% endif %}">
+                    {{ form_label( form.lastName, 'Last Name'|trans,  { 'attr': {'class': 'control-label'}} ) }}
+                    <div class="controls">
+                        {{ form_widget( form.lastName, { 'attr': {'class': 'span4'}} ) }}
+                        {{ form_errors( form.lastName ) }}
+                    </div>
+                </div>
+
+                <div class="control-group {% if form.email.vars.errors %}error{% endif %}">
+                    {{ form_label( form.email, 'Email'|trans,  { 'attr': {'class': 'control-label'}} ) }}
+                    <div class="controls">
+                        {{ form_widget( form.email, { 'attr': {'class': 'span6'}} ) }}
+                        {{ form_errors( form.email ) }}
+                    </div>
+                </div>
+
+                <div class="control-group {% if form.subject.vars.errors %}error{% endif %}">
+                    {{ form_label( form.subject, 'Subject'|trans,  { 'attr': {'class': 'control-label'}} ) }}
+                    <div class="controls">
+                        {{ form_widget( form.subject, { 'attr': {'class': 'span6'}} ) }}
+                        {{ form_errors( form.subject ) }}
+                    </div>
+                </div>
+
+                <div class="control-group {% if form.country.vars.errors %}error{% endif %}">
+                    {{ form_label( form.country, 'Country'|trans,  { 'attr': {'class': 'control-label'}} ) }}
+                    <div class="controls">
+                        {{ form_widget( form.country ) }}
+                        {{ form_errors( form.country ) }}
+                    </div>
+                </div>
+
+                <div class="control-group {% if form.message.vars.errors %}error{% endif %}">
+                    {{ form_label( form.message, 'Message'|trans,  { 'attr': {'class': 'control-label'}} ) }}
+                    <div class="controls">
+                        {{ form_widget( form.message, { 'attr': {'class': 'span8', 'rows': '10'} } ) }}
+                        {{ form_errors( form.message ) }}
+                    </div>
+                </div>
+
+                {{ form_widget( form.save, { 'label': "Send form"|trans, 'attr': { 'class': 'btn btn-warning pull-right' } } ) }}
+
+                {{ form_end( form ) }}
+            {% endfor %}
+        </div>
+    </div>
+</section>
+
+{% endblock %}


### PR DESCRIPTION
Link: https://jira.ez.no/browse/EZP-21846
## Description

Information collectors have not been implemented on 5.x. So for now, the DemoBundle displays a way to build a contact form using the Symfony form and to send an email using swiftmailer.
## Tests

Manual tests
## Screenshot

![feedbackform](https://f.cloud.github.com/assets/4035241/2418939/fe37ec22-ab52-11e3-9985-eaa0fe21e843.png)
## TODO
- [x] Form controller
- [x] General cleanup
- [x] Finish html/css
- [x] Rebase commits
