### PR TITLE
Fix EZP-22463: change the '[]' to work in a PHP 5.3

### DIFF
--- a/Controller/PlaceController.php
+++ b/Controller/PlaceController.php
@@ -65,6 +65,8 @@ class PlaceController extends Controller
         /** @var \EzSystems\DemoBundle\Helper\PlaceHelper $placeHelper */
         $placeHelper = $this->get( 'ezdemo.place_helper' );
 
+        $languages = $this->getConfigResolver()->getParameter( 'languages' );
+        $language = ( !empty( $languages ) ) ? $languages[0] : null;
         $sortClauses = array(
             new SortClause\MapLocationDistance(
                 "place",
@@ -72,7 +74,7 @@ class PlaceController extends Controller
                 $latitude,
                 $longitude,
                 Query::SORT_ASC,
-                $this->getConfigResolver()->getParameter( 'languages' )[0]
+                $language
             )
         );
 


### PR DESCRIPTION
Fix for issue [EZP-22463](https://jira.ez.no/browse/EZP-22463)

Change the array selector to work in a PHP 5.3

( This is the PR #57 with branch name fixed )
