### PR TITLE
Ezp 22476 no alias breaks page

### DIFF
--- a/Resources/views/fields/ezimage_simple.html.twig
+++ b/Resources/views/fields/ezimage_simple.html.twig
@@ -5,6 +5,9 @@
 {% block ezimage_field %}
     {% if not ez_is_field_empty( content, field ) %}
         {% set image_alias = ez_image_alias( field, versionInfo, parameters.alias|default( 'original' ) ) %}
-        <img src="{{ asset( image_alias.uri ) }}" width="{{ image_alias.width }}" height="{{ image_alias.height }}" alt="{{ parameters.alt|default( field.value.alternativeText ) }}" />
+        {# if image alias is not found, null is returned, an error is added in logs and the image is not displayed #}
+        {% if image_alias %}
+            <img src="{{ asset( image_alias.uri ) }}" width="{{ image_alias.width }}" height="{{ image_alias.height }}" alt="{{ parameters.alt|default( field.value.alternativeText ) }}" />
+        {% endif %}
     {% endif %}
 {% endblock %}


### PR DESCRIPTION
Link: https://jira.ez.no/browse/EZP-22476
## Description

In ezimage_simple.html.twig if image_alias is empty a stack will be thrown breaking the whole page.
https://github.com/ezsystems/DemoBundle/blob/master/Resources/views/fields/ezimage_simple.html.twig?source=c#L7

When a ez_image_alias is not found an error is already logged on the server:
https://github.com/ezsystems/ezpublish-kernel/blob/master/eZ/Publish/Core/MVC/Symfony/Templating/Twig/Extension/ContentExtension.php?source=c#L451

So this error should be silent on the frontend and not break the page.

The reason why the alias is not present will be fixed in another JIRA issue (https://jira.ez.no/browse/EZP-22477).
## Tests

Manual tets
