### PR TITLE
Add ContentContext and the tag for content test on startup page

### DIFF
--- a/Features/Context/ContentContext.php
+++ b/Features/Context/ContentContext.php
@@ -1,0 +1,22 @@
+<?php
+/**
+ * File containing the ContentContext class.
+ *
+ * This class contains specific feature context of the DemoBundle with content
+ * for Behat.
+ *
+ * @copyright Copyright (C) 1999-2014 eZ Systems AS. All rights reserved.
+ * @license http://www.gnu.org/licenses/gpl-2.0.txt GNU General Public License v2
+ * @version //autogentag//
+ */
+
+namespace EzSystems\DemoBundle\Features\Context;
+
+use EzSystems\DemoBundle\Features\Context\FeatureContext;
+
+/**
+ * Feature context.
+ */
+class ContentContext extends FeatureContext
+{
+}

--- a/Features/start_page.feature
+++ b/Features/start_page.feature
@@ -1,3 +1,4 @@
+@democontent
 Feature: Start page
 
     Scenario: Start page displays welcome text


### PR DESCRIPTION
It was decided to make BDD tests running through profiles.

To be able to make this PR https://github.com/ezsystems/ezpublish-community/pull/117 pass on travis, the ContentContext must be added first.
