### PR TITLE
impl/EZP-22298 Twig template to display a place content

### DIFF
--- a/Resources/config/ezdemo.yml
+++ b/Resources/config/ezdemo.yml
@@ -39,6 +39,10 @@ system:
                     template: "eZDemoBundle:full:place_list.html.twig"
                     match:
                         Identifier\ContentType: [place_list]
+                place:
+                    template: "eZDemoBundle:full:place.html.twig"
+                    match:
+                        Identifier\ContentType: [place]
 
             line:
                 article:

--- a/Resources/public/css/bootstrap.css
+++ b/Resources/public/css/bootstrap.css
@@ -5152,7 +5152,23 @@ div.ezcom-setting-mail {
     max-width: 100%;
     text-align: center;
   }
+  .place-image {
+    visibility: hidden;
+    display: none;
+  }
+  .place-name {
+    text-align: center;
+  }
 }
 .yui3-js-enabled .jsenable-place-list-info {
   display: none;
+}
+.place-image {
+  margin-top: 10px;
+  text-align: center;
+  margin-bottom: 15px;
+}
+.place-location {
+  margin-top: 10px;
+  margin-bottom: 15px;
 }

--- a/Resources/public/less/places.less
+++ b/Resources/public/less/places.less
@@ -36,8 +36,28 @@
     max-width: 100%;
     text-align: center;
   }
+
+  .place-image {
+    visibility: hidden;
+    display: none;
+  }
+
+  .place-name {
+    text-align: center;
+  }
 }
 
 .yui3-js-enabled .jsenable-place-list-info {
   display: none;
+}
+
+.place-image {
+  margin-top: 10px;
+  text-align: center;
+  margin-bottom: 15px;
+}
+
+.place-location {
+  margin-top: 10px;
+  margin-bottom: 15px;
 }

--- a/Resources/views/full/place.html.twig
+++ b/Resources/views/full/place.html.twig
@@ -1,0 +1,27 @@
+{% extends "eZDemoBundle::pagelayout.html.twig" %}
+{% block content %}
+<div>
+    <div class="row">
+        <div class="span6 place-name">
+            <h1>{{ ez_render_field( content, 'name' ) }}</h1>
+        </div>
+    </div>
+    <div class="row">
+        {% if not ez_is_field_empty( content, 'image' ) %}
+            <div class="span6">
+                {{ ez_render_field( content, 'image', { 'attr': { 'class': 'place-image' }, 'parameters': {'alias' : 'large'} } ) }}
+            </div>
+            <div class="span4">
+        {% else %}
+            <div class="span10">
+        {% endif %}
+                {{ ez_render_field( content, 'location', { 'attr': { 'class': 'place-location' },'parameters':{ 'showInfo':false, 'width': '100%' } } ) }}
+            </div>
+    </div>
+    <div class="row">
+        <div class="span8">
+            {{ ez_render_field( content, 'description' ) }}
+        </div>
+    </div>
+</div>
+{% endblock %}


### PR DESCRIPTION
## Description

The goal here was to create a template which displays a Place Content
## Links

Specification : https://confluence.ez.no/display/PR/Places
PS : one thing has changed from specification, it's the position of the title (Name content field), which is now above map and description (validated by product management).
## Screenshots

Here is one example in full view: 

![image](https://f.cloud.github.com/assets/5558766/2525270/9f3a9c70-b4ed-11e3-8c3b-5e673bb31603.png)

Here is one example in tablet/smartphone view:

![image](https://f.cloud.github.com/assets/5558766/2525278/b7951b6a-b4ed-11e3-9940-372adfdc3039.png)
