### PR TITLE
BDD: add missing 'site map' to page mapping

### DIFF
--- a/Features/Context/ContentContext.php
+++ b/Features/Context/ContentContext.php
@@ -24,6 +24,7 @@ class ContentContext extends FeatureContext
         parent::__construct( $parameters );
         $this->pageIdentifierMap += array(
             "search" => "/content/search",
+            "site map" => "/content/view/sitemap/2",
         );
 
         // specify the tags for specific content


### PR DESCRIPTION
Adding (wrongly removed b96db8f) "site map" to page mapping
