### PR TITLE
impl/EZP-22111 As an end user I want to see a place list on a map

### DIFF
--- a/Resources/public/css/bootstrap.css
+++ b/Resources/public/css/bootstrap.css
@@ -5161,6 +5161,23 @@ div.ezcom-setting-mail {
   margin-bottom: 25px;
   margin-top: 15px;
 }
+.place-list-gmap {
+  height: 0;
+  width: 0;
+  visibility: hidden;
+}
+.place-list-item .infobox-content {
+  display: none;
+}
+#place-list-gmap-container img {
+  max-width: none;
+}
+.place-list-map-size {
+  height: 550px;
+}
+.place-list-content-hidden {
+  display: none;
+}
 @media (max-width: 760px) {
   .place-list-form {
     float: none;
@@ -5176,6 +5193,9 @@ div.ezcom-setting-mail {
     display: none;
   }
   .place-name {
+    text-align: center;
+  }
+  .place-list-name {
     text-align: center;
   }
 }

--- a/Resources/public/less/places.less
+++ b/Resources/public/less/places.less
@@ -42,6 +42,28 @@
   margin-top: 15px;
 }
 
+.place-list-gmap {
+  height: 0;
+  width: 0;
+  visibility: hidden;
+}
+
+.place-list-item .infobox-content {
+  display: none
+}
+
+#place-list-gmap-container img {
+    max-width: none;
+}
+
+.place-list-map-size {
+  height: 550px;
+}
+
+.place-list-content-hidden {
+  display: none;
+}
+
 @media (max-width: 760px) {
   .place-list-form {
     float: none;
@@ -59,6 +81,10 @@
   }
 
   .place-name {
+    text-align: center;
+  }
+
+  .place-list-name {
     text-align: center;
   }
 }

--- a/Resources/views/full/place_list.html.twig
+++ b/Resources/views/full/place_list.html.twig
@@ -18,16 +18,28 @@
                         {{ 'Show places'|trans }}
                     </button>
                 </p>
+                <p>
+                    <button class="btn btn-warning btn-large" id="gmap-place-list" disabled="disabled">
+                        {{ 'View on Map'|trans }}
+                    </button>
+                    <div id="buttonContentMapHidden" class="place-list-content-hidden">
+                        {{ 'Hide Map'|trans }}
+                    </div>
+                </p>
             </form>
             <p id="sort-place-list-errors" class="place-list-text-error"></p>
             <p class="jsenable-place-list-info place-list-text-info">
                 {{ 'Javascript must be enabled in order to use the place list feature'|trans }}
             </p>
         </div>
+
         <div class="row">
-            <div class="span8">
+            <div class="span9 place-list-name">
                 <h1>{{ ez_render_field( content, 'name') }}</h1>
 
+                <div id="place-list-gmap-container" class="place-list-gmap"  >
+                    <div id="maplocation-map" class="place-list-map-size"></div>
+                </div>
                 <div id="place-list-container">
                     {{ render( controller(
                             'eZDemoBundle:Place:listPlaceList',
@@ -39,6 +51,7 @@
             </div>
         </div>
     </section>
+    <script type="text/javascript" src="http://maps.google.com/maps/api/js?sensor=true"></script>
     <script>
         YUI(YUI3_config).use('io-base', 'node', function(Y) {
             //Generating URL with keys values that will be replaced when clicking
@@ -50,61 +63,107 @@
                 disabledGeoLocateMsg = '{{ 'Geolocation feature is disabled on your browser. Check the permission settings to allow it.'|trans }}',
                 ajaxErrorMsg = '{{ 'Your request has failed, please try again later.'|trans }}',
                 container = Y.one('#place-list-container'),
-                sortButton = Y.one('#sort-place-list'),
+                sortedPlaceButton = Y.one('#sort-place-list'),
+                displayMapButton = Y.one('#gmap-place-list'),
                 errorContainer = Y.one('#sort-place-list-errors'),
-                distanceList = Y.one('#max-dist-place-list');
+                distanceList = Y.one('#max-dist-place-list'),
+                mapContainer = Y.one('#place-list-gmap-container'),
+                buttonContentVisibleMap = displayMapButton.getContent(),
+                buttonContentHiddenMap = Y.one('#buttonContentMapHidden').getContent(),
+                markers=[];
 
             if ("geolocation" in navigator) {
-                sortButton.set('disabled', false);
+                sortedPlaceButton.set('disabled', false);
+                displayMapButton.set('disabled', false);
                 distanceList.set('disabled', false);
-            }else{
+            } else {
                 errorContainer.setHTML(noGeoLocateMsg);
             }
 
-            /**
-             * Updates a sorted list of places
-             * @params string uri of ajax method
-             * @params function callback executed on success of the ajax request
-             */
-            function updatePlaceList(uri, onSuccessPlaceList)
-            {
-                var config = {
-                    method: 'GET',
-                    on: {
-                        success: onSuccessPlaceList,
-                        failure: function (id, response) {
-                            container.removeClass('place-list-loading');
-                            errorContainer.setHTML(ajaxErrorMsg);
-                        }
+            displayMapButton.on('click', function (e) {
+                var placeList = Y.all('.place-list-item'),
+                    mapView,
+                    i;
+
+                e.preventDefault();
+                //The marker's array is reseted before each map init
+                markers = [];
+                mapView = function(mapId, latitude, longitude) {
+                    var map = new google.maps.Map(document.getElementById(mapId), {
+                                center: new google.maps.LatLng(latitude, longitude),
+                                zoom: 13,
+                                draggable: true,
+                                mapTypeId: google.maps.MapTypeId.ROADMAP
+                            }),
+                        infowindow = new google.maps.InfoWindow();
+                    //Markers are made from the data-attributes of the place list displayed
+                    placeList.each(function (place) {
+                        var marker = new google.maps.Marker( {
+                            position: new google.maps.LatLng(
+                                place.getData('place-lat'),
+                                place.getData('place-long')
+                            ),
+                            title: place.getData('place-name'),
+                            animation: google.maps.Animation.DROP
+                        } );
+                        markers.push(marker);
+                        google.maps.event.addListener(marker, 'click', function () {
+                            infowindow.setContent(place.one('.infobox-content').getContent());
+                            infowindow.setPosition(this.position);
+                            infowindow.open(map, this);
+                        } );
+                    });
+                    for (i = 0; i < markers.length; i++) {
+                        markers[i].setMap(map);
                     }
                 };
 
-                Y.io( uri, config );
-            }
+                navigator.geolocation.getCurrentPosition(function(position) {
+                    mapView("maplocation-map", position.coords.latitude, position.coords.longitude);
+                } );
 
-            sortButton.on('click', function (e) {
+                if (mapContainer.hasClass("place-list-gmap")) {
+                    displayMapButton.setHTML(buttonContentHiddenMap);
+                } else {
+                    displayMapButton.setHTML(buttonContentVisibleMap);
+                }
+
+                mapContainer.toggleClass("place-list-gmap");
+            });
+
+            sortedPlaceButton.on('click', function (e) {
+
                 e.preventDefault();
                 container.addClass('place-list-loading');
 
                 navigator.geolocation.getCurrentPosition(function (position) {
-
-                    var uri = '{{ path(
-                        'ezpublish_ezdemo_ajax_sorted_place_list',
-                        {'locationId': location.id, 'latitude': 'key_lat', 'longitude': 'key_lon','maxDist': 'key_dist'}
-                        ) }}',
-                        maxDist = distanceList.get('value');
-
+                    var maxDist = distanceList.get('value');
                     //Case maxdist == 0 allows to show all places (unsorted list)
-                    if (maxDist == 0){
+                    if (maxDist == 0) {
                         uri = '{{ path('ezpublish_ezdemo_ajax_default_placeList',{ 'locationId': location.id } ) }}';
-                    }else{
+                    } else {
                         uri = uri.replace('key_lat', position.coords.latitude).replace('key_lon', position.coords.longitude).replace('key_dist', maxDist);
                     }
-
-                    updatePlaceList(uri, function(id, response) {
-                        container.setHTML(response.responseText);
-                        container.removeClass('place-list-loading');
-                    });
+                    var config = {
+                        method: 'GET',
+                        on: {
+                            success: function (id, response) {
+                                container.setHTML(response.responseText);
+                                container.removeClass('place-list-loading');
+                                //if map open we update it and keep it open
+                                if(!mapContainer.hasClass("place-list-gmap")) {
+                                    displayMapButton.invoke('click');
+                                    mapContainer.toggleClass("place-list-gmap");
+                                    displayMapButton.setHTML(buttonContentHiddenMap);
+                                }
+                            },
+                            failure: function (id, response) {
+                                container.removeClass('place-list-loading');
+                                errorContainer.setHTML(ajaxErrorMsg);
+                            }
+                        }
+                    };
+                    Y.io( uri, config );
                 }, function () {
                     container.removeClass('place-list-loading');
                     errorContainer.setHTML(disabledGeoLocateMsg);

--- a/Resources/views/line/place.html.twig
+++ b/Resources/views/line/place.html.twig
@@ -1,11 +1,25 @@
 {#
   Displays a place (in a list)
 #}
-<div>
-    <a href="{{ path( 'ez_urlalias', {'locationId': content.contentInfo.mainLocationId} ) }}">
-        <h2>{{ ez_render_field( content, 'name' ) }}</h2>
-    </a>
+<div class="place-list-item"
+    data-place-name="{{ ez_content_name( content ) }}"
+    data-place-lat="{{ ez_field_value( content, 'location' ).latitude }}"
+    data-place-long="{{ ez_field_value( content, 'location' ).longitude }}">
+    <h2>
+        <a href="{{ path( 'ez_urlalias', {'locationId': content.contentInfo.mainLocationId} ) }}">
+            {{ ez_content_name( content, 'name' ) }}
+        </a>
+    </h2>
 
+    <div class="infobox-content">
+        <h2>
+            <a href="{{ path( 'ez_urlalias', {'locationId': content.contentInfo.mainLocationId} ) }}">
+                {{ ez_content_name( content ) }}
+            </a>
+        </h2>
+        {{ ez_render_field( content, 'image', { 'attr': { 'class': 'place-list-image' }, 'parameters': {'alias' : 'small'} } ) }}
+    </div>
+    
     <div class="row">
         {% if ez_is_field_empty( content, 'image' ) %}
             <div class="span8">
@@ -20,6 +34,8 @@
             </div>
         {% endif %}
 
+    </div>
+    <div class="row span8">
         <a class="place-list-link" href="{{ path( 'ez_urlalias', {'locationId': content.contentInfo.mainLocationId} ) }}"> >> {{ 'more'|trans }}</a>
     </div>
 </div>


### PR DESCRIPTION
## Description

The goal here was to get the places of the place list view displayed on a Gmap. A new button has appeared to display the view which is hidden  by default. If the list is sorted by distance, only the places shown in the list will be displayed on the map, furthermore the map is updated with the list. The map's center is defined by geolocalisation.
## Link

Specifications: https://confluence.ez.no/display/PR/Places
Jira: https://jira.ez.no/browse/EZP-22111
## Screenshots

Here we can see the page with the map hidden:

![screenshot from 2014-05-06 11 12 14](https://cloud.githubusercontent.com/assets/5558766/2887686/8e8a778e-d4fe-11e3-9836-a05adb84449c.png)

Here we can see when the map is displayed, when we click on a marker an infowindow with the link to the full place page and the main image is opened. We also display the name of the place by passing the cursor over the marker.

![screenshot from 2014-05-06 11 09 15](https://cloud.githubusercontent.com/assets/5558766/2887666/46fb364c-d4fe-11e3-94f5-afc680ddf053.png)
