### PR TITLE
Fixed EZP-22823: exception in Preview w/ website toolbar

### DIFF
--- a/Resources/views/pagelayout.html.twig
+++ b/Resources/views/pagelayout.html.twig
@@ -16,7 +16,7 @@
 </head>
 <body>
 <!-- Complete page area: START -->
-{% if location is defined %}
+{% if location is defined and location.id is not null %}
     {{ render( controller( "ezpublish_legacy.website_toolbar.controller:websiteToolbarAction", { 'locationId': location.id} ) ) }}
 {% endif %}
 <div id="page" class="">


### PR DESCRIPTION
> Fixes http://jira.ez.no/browse/EZP-22823

An exception is thrown by Twig/Stash if the websitetoolbar is enabled with the provided configuration, and a Preview is requested.

In the PreviewController, a fake Location is created, with among others `id`set to `null`. This null ID is passed on to the website toolbar render, and content is loaded by the API from a null ID.

If we go this way, it also needs to be documented like this.
