### PR TITLE
Fix EZP-22604:  Add space separator between tag cloud's words

### DIFF
--- a/Resources/public/css/bootstrap.css
+++ b/Resources/public/css/bootstrap.css
@@ -4815,6 +4815,9 @@ a.thumbnail:hover {
 .content-view-aside .block-type-tagcloud .block-content {
   padding: 10px 20px;
 }
+.content-view-aside .block-type-tagcloud a {
+  padding-right: 0.2em;
+}
 .block-type-campaign {
   margin-bottom: 1em;
 }

--- a/Resources/public/less/blocks.less
+++ b/Resources/public/less/blocks.less
@@ -96,5 +96,8 @@
         .block-content {
             padding: 10px 20px;
         }
+        a {
+            padding-right: 0.2em;
+        }
     }
 }


### PR DESCRIPTION
## Link

https://jira.ez.no/browse/EZP-22604
## Description

The goal here is to put space separator between words in the tag cloud block of the home page.

![tagg](https://cloud.githubusercontent.com/assets/5558661/2946010/33cea4b2-d9e7-11e3-8c09-77b1abd18ebd.png)
