### PR TITLE
EZP-22550 Added breadcrumb to navigate in Demobundle

### DIFF
--- a/Resources/config/wobreadcrumb.yml
+++ b/Resources/config/wobreadcrumb.yml
@@ -1,0 +1,2 @@
+services:
+    white_october_breadcrumbs: ~

--- a/Resources/public/css/bootstrap.css
+++ b/Resources/public/css/bootstrap.css
@@ -1654,6 +1654,12 @@ del:hover {
   border-bottom: none;
   text-decoration: none;
 }
+#wo-breadcrumbs {
+  padding-bottom: 0px;
+}
+#wo-breadcrumbs li:before {
+  content: none;
+}
 p {
   margin: 0 0 10.5px;
   font-family: Arial, Helvetica, sans-serif;

--- a/Resources/public/less/layouts.less
+++ b/Resources/public/less/layouts.less
@@ -1042,3 +1042,11 @@ del:hover {
     border-bottom: none;
     text-decoration: none;
 }
+
+#wo-breadcrumbs {
+    padding-bottom: 0px;
+}
+
+#wo-breadcrumbs li:before {
+    content: none;
+}

--- a/Resources/views/breadcrumb.html.twig
+++ b/Resources/views/breadcrumb.html.twig
@@ -1,0 +1,1 @@
+{{ wo_render_breadcrumbs( {separator: '>>'} ) }}

--- a/Resources/views/pagelayout.html.twig
+++ b/Resources/views/pagelayout.html.twig
@@ -41,6 +41,11 @@
         <!-- Path area: END -->
     </div>
     <div class="container">
+        {% block breadcrumb %}
+            {% if location is defined and not location.isDraft %}
+                {{ render( controller( 'eZDemoBundle:Demo:viewBreadcrumb', { 'locationId': location.id } ) ) }}
+            {% endif %}
+        {% endblock %}
         <div class="row">
             <!-- Main area: START -->
             <div class="span{{ innerColumnSize|default( 12 ) }} main-content">


### PR DESCRIPTION
## Description

The goal here was to add a breadcrumb to be able to naviguate in the Demobundle. For that I implemented a new bundle from white october named BreadCrumbsBundle ( see link to whiteoctober bundle ).
To work this bundle need to be registred in ezPublishKernel.php and in composer.json ( see link to ezpublish-community pull request ).
## Links

Jira : https://jira.ez.no/browse/EZP-22550
Whiteoctober BreadCrumbsBundle : https://github.com/whiteoctober/BreadcrumbsBundle 
Ezpublish-community pull request link : https://github.com/ezsystems/ezpublish-community/pull/150
## Screenshot

![screenshot from 2014-05-14 13 53 59](https://cloud.githubusercontent.com/assets/5558766/2970644/812d9ea2-db5e-11e3-96a8-4bb0d48b91b9.png)
