### PR TITLE
Fix EZP-22767: Added calls to ez_legacy_render_js and ez_legacy_render_css

### DIFF
--- a/Resources/views/page_head_script.html.twig
+++ b/Resources/views/page_head_script.html.twig
@@ -21,3 +21,5 @@ var YUI3_config = {base: "{{ asset( 'extension/ezjscore/design/standard/lib/yui/
 %}
     <script type="text/javascript" src="{{ asset_url }}"></script>
 {% endjavascripts %}
+
+{{ ez_legacy_render_js() }}

--- a/Resources/views/page_head_style.html.twig
+++ b/Resources/views/page_head_style.html.twig
@@ -10,3 +10,5 @@
 <style type="text/css">
     @import url("{{ asset('extension/ezwt/design/standard/stylesheets/websitetoolbar.css') }}");
 </style>
+
+{{ ez_legacy_render_css() }}


### PR DESCRIPTION
Link: https://jira.ez.no/browse/EZP-22767
## Description

This is needed in order to have ezjscore requirements loaded when using legacy modules.

See related: https://github.com/ezsystems/ezpublish-kernel/pull/833
## Tests

Manual tests
