### PR TITLE
EZP-22933

### DIFF
--- a/Resources/views/full/place_list.html.twig
+++ b/Resources/views/full/place_list.html.twig
@@ -95,7 +95,8 @@
                                 draggable: true,
                                 mapTypeId: google.maps.MapTypeId.ROADMAP
                             }),
-                        infowindow = new google.maps.InfoWindow();
+                        infowindow = new google.maps.InfoWindow(),
+                        latlngbounds = new google.maps.LatLngBounds();
                     //Markers are made from the data-attributes of the place list displayed
                     placeList.each(function (place) {
                         var marker = new google.maps.Marker( {
@@ -113,8 +114,15 @@
                             infowindow.open(map, this);
                         } );
                     });
-                    for (i = 0; i < markers.length; i++) {
-                        markers[i].setMap(map);
+                    if( markers.length ) {
+                        for (i = 0; i < markers.length; i++) {
+                            markers[i].setMap(map);
+                            // extend bounds with the position of the marker
+                            latlngbounds.extend(markers[i].position);
+                        }
+                        // finally extend bounds with the map center
+                        latlngbounds.extend(map.center);
+                        map.fitBounds(latlngbounds);
                     }
                 };
 


### PR DESCRIPTION
When seing several geo-content objects on one map, zoom is not adjusted for the corpus

Implements https://jira.ez.no/browse/EZP-22933

I love playing with gMaps and i've seen Roland has created an issue for the DemoBundle

Here's my proposed solution. 
- If the search returns no results, then the map is centered and zoom remains "13" (default)
- if the search returns results, then we extend the latlngBounds with each marker position and finally with the center of the map too. This way, all mountains will be visible in the map and you can see that distance from your geolcation point. 

Le me know if it helps. 
