### PR TITLE
Fixed: EZP-22989 Blog Calendar in demobundle only allows you navigate to...

### DIFF
--- a/Resources/views/parts/blog/extra_info.html.twig
+++ b/Resources/views/parts/blog/extra_info.html.twig
@@ -3,4 +3,4 @@
  # You can look at the DemoController calling this template to have a good example on own to sandbox
  # a legacy feature inside a controller using a subrequest.
  #}
-{% include "design:parts/blog/extra_info.tpl" with {"used_node": location } %}
+{% include "design:parts/blog/extra_info.tpl" with {"used_node": location, "view_parameters": ezpublish.viewParameters } %}


### PR DESCRIPTION
... previous and next month

Fixes: https://jira.ez.no/browse/EZP-22989

Is this the right way to proceed? It's normal view_parameters variable is not available to the legacy template? 

Please let me know. 
