### PR TITLE
Fix EZP-22840: Editor user missing access to frontend

### DIFF
--- a/Controller/DemoController.php
+++ b/Controller/DemoController.php
@@ -310,6 +310,9 @@ class DemoController extends Controller
 
         $isRootLocation = false;
 
+        // Shift of location "1" from path as it is not a fully valid location and not readable by most users
+        array_shift( $path );
+
         for ( $i = 0; $i < count( $path ); $i++ )
         {
             $location = $locationService->loadLocation( $path[$i] );


### PR DESCRIPTION
Actually fixing issues introduced in EZP-22550 "Added breadcrumb to
navigate in Demobundle" by making sure location 1 (which editor does
not have access to) is not loaded as part of bread crumbs.

Could be argued that Editor should inherit Anonymous role to get
access, but that is currently not the case, and besides this saves
a uneeded load call either way.
