### PR TITLE
Fix EZP-23241 - KnpMenu not showing menu bar when there is no content

### DIFF
--- a/Resources/views/page_topmenu.html.twig
+++ b/Resources/views/page_topmenu.html.twig
@@ -4,7 +4,9 @@
         <a class="btn btn-navbar" data-action="toggleclass" data-class="nav-collapse" data-target=".main-navi .nav-collapse">{{ "Navigation"|trans }}</a>
 
         <div class="nav-collapse">
-            {{ knp_menu_render(menu, {'depth': 1, 'firstClass': 'firstli', 'lastClass': 'lastli', 'branch_class': 'nav'}) }}
+            <div class="nav">
+                {{ knp_menu_render(menu, {'depth': 1, 'firstClass': 'firstli', 'lastClass': 'lastli'}) }}
+            </div>
         </div>
 
     </div>


### PR DESCRIPTION
#### EZP-23241 - KnpMenu not showing menu bar when there is no content

If you make a clean installation, you'll notice the blue menu bar won't appear until you had a new folder

https://jira.ez.no/browse/EZP-23241
