### PR TITLE
Fix EZP-23248 - Notice when accessing eZ Demo frontpage

### DIFF
--- a/Controller/MenuController.php
+++ b/Controller/MenuController.php
@@ -22,7 +22,11 @@ class MenuController extends Controller
     {
         if ( $currentLocationId !== null )
         {
-            $secondLevelLocationId = $this->getLocationService()->loadLocation( $currentLocationId )->path[2];
+            $location = $this->getLocationService()->loadLocation( $currentLocationId );
+            if ( isset( $location->path[2] ) )
+            {
+                $secondLevelLocationId = $location->path[2];
+            }
         }
 
         $response = new Response;


### PR DESCRIPTION
#### EZP-23248 - Notice when accessing eZ Demo frontpage

Having xdebug enabled and display_errors= on, wheni install an eZ Demo without content package, i have the following notice when i access the eZ Demo frontpage:

```
Notice: Undefined offset: 2 in /var/www/ezpublish5/vendor/ezsystems/demobundle/EzSystems/DemoBundle/Controller/MenuController.php on line 25
```
