### PR TITLE
Fix EZP-23325: Return after redirecting on feedback form submission

### DIFF
--- a/Controller/FeedbackFormController.php
+++ b/Controller/FeedbackFormController.php
@@ -53,7 +53,7 @@ class FeedbackFormController extends Controller
                     $this->get( 'translator' )->trans( 'Thank you for your message, we will get back to you as soon as possible.' )
                 );
 
-                $this->redirect(
+                return $this->redirect(
                     $this->generateUrl(
                         $this->getRepository()->getLocationService()->loadLocation( $locationId )
                     )


### PR DESCRIPTION
Fixes: https://jira.ez.no/browse/EZP-23325

This patch will prevent duplicate form submissions from the feedback form. 
The redirect had no effect without the return
