### PR TITLE
Allow to disable the default ezdemo_frontend_group siteaccess group

### DIFF
--- a/DependencyInjection/eZDemoExtension.php
+++ b/DependencyInjection/eZDemoExtension.php
@@ -59,5 +59,16 @@ class eZDemoExtension extends Extension implements PrependExtensionInterface
         $ezCommentsConfig = Yaml::parse( file_get_contents( $ezCommentsConfigFile ) );
         $container->prependExtensionConfig( 'ez_comments', $ezCommentsConfig );
         $container->addResource( new FileResource( $ezCommentsConfigFile ) );
+
+        // ezdemo.ezdemo_frontend_group.siteaccess_group_enabled must be defined before we get here
+        // or we assume true
+        if ( !$container->hasParameter('ezdemo.ezdemo_frontend_group.siteaccess_group_enabled')
+            || $container->getParameter('ezdemo.ezdemo_frontend_group.siteaccess_group_enabled') === true )
+        {
+            $siteAccessConfigFile = __DIR__ . '/../Resources/config/siteaccess.yml';
+            $siteAccessConfig = Yaml::parse( file_get_contents( $siteAccessConfigFile ) );
+            $container->prependExtensionConfig( 'ezpublish', $siteAccessConfig );
+            $container->addResource( new FileResource( $siteAccessConfigFile ) );
+        }
     }
 }

--- a/Resources/config/default_settings.yml
+++ b/Resources/config/default_settings.yml
@@ -30,3 +30,8 @@ parameters:
     ezdemo.feedback_form.email_to: root@localhost
     # Email address displayed as sent
     ezdemo.feedback_form.email_from: noreply@ezdemobundle.test
+
+    # Allows to disable the default ezdemo_frontend_group siteaccess group so user defined siteaccess group
+    # can take precedence.
+    # If not enabled sites mmust be added to the ezdemo_frontend_group siteaccess group manualy
+    ezdemo.ezdemo_frontend_group.siteaccess_group_enabled: true

--- a/Resources/config/ezdemo.yml
+++ b/Resources/config/ezdemo.yml
@@ -1,11 +1,3 @@
-siteaccess:
-    groups:
-        ezdemo_frontend_group:
-            - ezdemo_site
-            - ezdemo_site_user
-            - eng
-            - fre
-
 system:
     ezdemo_frontend_group:
         image_variations:

--- a/Resources/config/siteaccess.yml
+++ b/Resources/config/siteaccess.yml
@@ -1,0 +1,7 @@
+siteaccess:
+    groups:
+        ezdemo_frontend_group:
+            - ezdemo_site
+            - ezdemo_site_user
+            - eng
+            - fre


### PR DESCRIPTION
DemoBundle prepends the ezdemo_frontend_group siteaccess group configuration.

This can become an issue when extending DemoBundle as it must be loaded first.  This makes ezdemo_frontend_group take precedence over any other siteaccess group a user may define and does not allow the user to define the order on their own.

This allows a user to define ezdemo.ezdemo_frontend_group.siteaccess_group_enabled: false in ezpublish.yml to disable this behaviour and allow the user to define the group order they wish.
