### PR TITLE
EZP-21527: BDD update for ezdemo_simple_search form field

### DIFF
--- a/Features/Context/Demo.php
+++ b/Features/Context/Demo.php
@@ -40,7 +40,7 @@ class Demo extends Context
     public function iSearchFor( $search )
     {
         // workaround to get the search box that doesn't have a unique way to do it
-        $elements = $this->getXpath()->findFields( 'SearchText' );
+        $elements = $this->getXpath()->findFields( 'ezdemo_simple_search[searchText]' );
         Assertion::assertEquals(
             2,
             count( $elements ),
@@ -73,7 +73,6 @@ class Demo extends Context
         Assertion::assertRegExp(
             "/Search for \"(.*)\" returned {$total} matches/",
             $resultCountElement[0]->getText()
-
         );
     }
 }


### PR DESCRIPTION
JIRA: https://jira.ez.no/browse/EZP-21527

In continuation of PR #106, this updates bdd context to use the correct search form field.
(fixes travis failure in demo/content test)
