### PR TITLE
Added embed/image.html.twig template

### DIFF
--- a/Resources/config/ezdemo.yml
+++ b/Resources/config/ezdemo.yml
@@ -69,6 +69,12 @@ system:
                     template: "eZDemoBundle:line:place.html.twig"
                     match:
                         Identifier\ContentType: [place]
+        content_view:
+            embed:
+                image:
+                    template: "eZDemoBundle:embed:image.html.twig"
+                    match:
+                        Identifier\ContentType: [image]
 
         field_templates:
             - {template: "eZDemoBundle::content_fields.html.twig", priority: 10}

--- a/Resources/views/embed/image.html.twig
+++ b/Resources/views/embed/image.html.twig
@@ -1,0 +1,24 @@
+<div class="content-view-embed">
+    <div class="class-image">
+        <div class="attribute-image">
+            {% if not ez_is_field_empty( content, 'image' ) %}
+                <div class="attribute-image full-head">
+                    {{ ez_render_field(
+                        content,
+                        'image',
+                        {
+                            'template': 'eZDemoBundle:fields:ezimage_simple.html.twig',
+                            'parameters': { 'alias': objectParameters.size }
+                        }
+                    ) }}
+
+                    {% if not ez_is_field_empty( content, 'caption' ) %}
+                        <div class="attribute-caption">
+                            {{ ez_render_field( content, 'caption' ) }}
+                        </div>
+                    {% endif %}
+                </div>
+            {% endif %}
+        </div>
+    </div>
+</div>


### PR DESCRIPTION
This adds a native template for embedded images, so that decorated uris are correctly used.
