### PR TITLE
EZP-23546: adding language switcher to DemoBundle

### DIFF
--- a/.idea/php.xml
+++ b/.idea/php.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="PhpProjectSharedConfiguration" php_language_level="5.3.0" />
+</project>
+

--- a/Controller/LanguageSwitcherController.php
+++ b/Controller/LanguageSwitcherController.php
@@ -1,0 +1,31 @@
+<?php
+namespace EzSystems\DemoBundle\Controller;
+
+use eZ\Bundle\EzPublishCoreBundle\Controller;
+use eZ\Publish\Core\MVC\Symfony\Routing\RouteReference;
+
+class LanguageSwitcherController extends Controller
+{
+    public function languagesAction( RouteReference $routeReference )
+    {
+        // get a tab with info for existing siteaccess
+        $translationHelper = $this->container->get( 'ezpublish.translation_helper' );
+        $availableLanguage = $translationHelper->getAvailableLanguages();
+        // create an array for corresponding siteaccesses names depending on the lang
+        foreach ( $availableLanguage as $lang ) {
+            $siteaccess[$lang] = $translationHelper->getTranslationSiteAccess( $lang );
+        }
+
+        // get current eZ language
+        $currentSFLanguage = $this->getRequest()->get( '_locale' );
+        $currentEzLanguage = array_search(
+            $currentSFLanguage ,
+            $this->container->getParameter( 'ezpublish.locale.conversion_map' )
+        );
+
+        return $this->render( 'eZDemoBundle:parts:languages_switcher.html.twig',
+            array( 'routeRef' => $routeReference,
+                   'siteaccess' => $siteaccess,
+                   'currentLanguage' => $currentEzLanguage ) );
+    }
+}

--- a/Resources/config/ezdemo.yml
+++ b/Resources/config/ezdemo.yml
@@ -5,8 +5,13 @@ siteaccess:
             - ezdemo_site_user
             - eng
             - fre
+        language_switcher_group:
+            - eng
+            - fre
 
 system:
+    language_switcher_group:
+        translation_siteaccesses: [fre, eng]
     ezdemo_frontend_group:
         image_variations:
             #this is a new image's size used in the place template

--- a/Resources/views/page_header.html.twig
+++ b/Resources/views/page_header.html.twig
@@ -1,6 +1,9 @@
 <header>
     <div class="container">
         <div class="navbar extra-navi">
+            <div id="language-switcher" class="pull-right">
+                {{ render( controller( 'eZDemoBundle:LanguageSwitcher:languages', {'routeReference': ez_route()} ) ) }}
+            </div>
             <div class="nav-collapse row">
 
                 {% block userlinks %}

--- a/Resources/views/parts/languages_switcher.html.twig
+++ b/Resources/views/parts/languages_switcher.html.twig
@@ -1,0 +1,15 @@
+{# Looping over all available languages to display the links #}
+<div id="lang-selector">
+    {% for lang in ezpublish.availableLanguages %}
+        {# This time, we alter the "siteaccess" parameter directly. #}
+        {# We get the right siteaccess with the help of ezpublish.translationSiteAccess() helper #}
+
+        {% do routeRef.set( "siteaccess", ezpublish.translationSiteAccess( lang ) ) %}
+        {% if lang != currentLanguage %}
+            <a href="{{ url( routeRef ) }}" title="Switch to {{ siteaccess[lang] }}">
+                <img src="{{ asset( '/share/icons/flags/' ~ lang ~ '.gif' ) }}" title="{{ lang }}">
+                {{ siteaccess[lang]}}
+            </a>
+        {% endif %}
+    {% endfor %}
+</div>


### PR DESCRIPTION
Language switcher was missing in the demoBundle.
I just added it into DemoBundle for eng <-> fre siteaccess as an example.
There is no design (for bootstrap3, please see http://share.ez.no/blogs/huck-florent/language-switcher-using-bootstrap3/(language)/eng-GB). 
It only display a list with flags and siteaccesses name on the top right corner.

Link: https://jira.ez.no/browse/EZP-23546

