### PR TITLE
Fix EZP-22839: DemoBundle settings hardcoded to specific siteaccess names/group

### DIFF
--- a/DependencyInjection/eZDemoExtension.php
+++ b/DependencyInjection/eZDemoExtension.php
@@ -45,6 +45,11 @@ class eZDemoExtension extends Extension implements PrependExtensionInterface
      */
     public function prepend( ContainerBuilder $container )
     {
+        $legacyConfigFile = __DIR__ . '/../Resources/config/legacy_settings.yml';
+        $config = Yaml::parse( file_get_contents( $legacyConfigFile ) );
+        $container->prependExtensionConfig( 'ez_publish_legacy', $config );
+        $container->addResource( new FileResource( $legacyConfigFile ) );
+
         $configFile = __DIR__ . '/../Resources/config/ezdemo.yml';
         $config = Yaml::parse( file_get_contents( $configFile ) );
         $container->prependExtensionConfig( 'ezpublish', $config );

--- a/Resources/config/ezdemo.yml
+++ b/Resources/config/ezdemo.yml
@@ -7,7 +7,7 @@ siteaccess:
             - fre
 
 system:
-    ezdemo_frontend_group:
+    default:
         user:
             layout: eZDemoBundle::pagelayout.html.twig
             login_template: eZDemoBundle:Security:login.html.twig

--- a/Resources/config/ezpage.yml
+++ b/Resources/config/ezpage.yml
@@ -1,5 +1,5 @@
 system:
-    ezdemo_frontend_group:
+    default:
         # Configuration for block views.
         # This configuration is used when using sub-requests on ez_page:viewBlock.
         # Block views are triggered from eZPage Zone layouts.

--- a/Resources/config/legacy_settings.yml
+++ b/Resources/config/legacy_settings.yml
@@ -1,0 +1,5 @@
+system:
+    default:
+        templating:
+            view_layout: "eZDemoBundle::pagelayout.html.twig"
+            module_layout: "eZDemoBundle::pagelayout_legacy.html.twig"

--- a/Resources/config/services.yml
+++ b/Resources/config/services.yml
@@ -10,8 +10,6 @@ parameters:
     # Default limit that will be applied when retrieving content for menus.
     ezdemo.menu_helper.default_limit: 10
 
-    ezpublish_legacy.ezdemo_frontend_group.module_default_layout: "eZDemoBundle::pagelayout_legacy.html.twig"
-
 services:
     ezdemo.criteria_helper:
         class: %ezdemo.criteria_helper.class%


### PR DESCRIPTION
> https://jira.ez.no/browse/EZP-22839

Changed `ezdemo_frontend_group` to `default`.
This was not possible before since `default` keyword wasn't taken into account in semantic config.

Also added pagelayout configuration for legacy to its own file, using semantic configuration for EzLegacyBundle. Thus `ezpublish.default.view_default_layout` should be removed from default
`parameters.yml.dist`.
