### PR TITLE
Fix EZP-23622: Link for "For more options try the advanced search" in DemoBundle loses words

### DIFF
--- a/Resources/views/search/search.html.twig
+++ b/Resources/views/search/search.html.twig
@@ -31,7 +31,7 @@
     {% set advancedSearchUrl = '' %}
 
     {% if searchText %}
-        {% set advancedSearchUrl = '?SearchText=' ~ searchText %}
+        {% set advancedSearchUrl = '?SearchText=' ~ searchText|replace({' ': '+'}) %}
     {% endif %}
 
     <p>


### PR DESCRIPTION
### EZP-23622: Link for "For more options try the advanced search" in DemoBundle loses words

If you make a search of two words (New Article) in the Search input box in Demobundle, when it displays the results it will also show a link for "For more options try the advanced search". This link will only consider the first word, ignoring the other ones

Link: https://jira.ez.no/browse/EZP-23622
