### PR TITLE
Fix: EZP-23682 - [Demo] Getting Started, Shopping and Contact Us not present on the menu

### DIFF
--- a/Resources/config/default_settings.yml
+++ b/Resources/config/default_settings.yml
@@ -36,7 +36,7 @@ parameters:
     ezdemo.search.list.limit: 10
 
     ## Menu. Overrides MenuContentSettings.TopIdentifierList from ezpublish_legacy/settings/menu.ini.
-    menu.default.menucontentsettings.topidentifierlist: [folder, gallery, place_list]
+    menu.default.menucontentsettings.topidentifierlist: [landing_page, folder, gallery, place_list, blog, feedback_form]
 
     ## Premium content
     ezdemo.premium_content.section_id: 7


### PR DESCRIPTION
### EZP-23682 - [Demo] Getting Started, Shopping and Contact Us not present on the menu

Apparently the links to Getting Started, Shopping and Contact Us as missing on the menu bar, instead Resources, Select Features, Products and Services are present
