### PR TITLE
Fix unused response in FolderController

### DIFF
--- a/Controller/FolderController.php
+++ b/Controller/FolderController.php
@@ -29,7 +29,7 @@ class FolderController extends Controller
      * @throws NotFoundHttpException $location is flagged as invisible
      * @return \Symfony\Component\HttpFoundation\Response
      */
-    public function showFolderListAsideViewAction( Location $location, $viewType, $layout = false )
+    public function showFolderListAsideViewAction( Location $location, $viewType, $layout = false, array $params = array() )
     {
         if ( $location->invisible )
         {
@@ -64,7 +64,7 @@ class FolderController extends Controller
             $location->id,
             $viewType,
             $layout,
-            ['treeChildItems' => $treeChildItems]
+            array( 'treeChildItems' => $treeChildItems ) + $params
         );
     }
 
@@ -76,7 +76,7 @@ class FolderController extends Controller
      * @throws NotFoundHttpException $location is flagged as invisible
      * @return \Symfony\Component\HttpFoundation\Response
      */
-    public function showFolderListAction( Request $request, Location $location, $viewType, $layout = false )
+    public function showFolderListAction( Request $request, Location $location, $viewType, $layout = false, array $params = array() )
     {
         if ( $location->invisible )
         {
@@ -139,7 +139,7 @@ class FolderController extends Controller
             $location->id,
             $viewType,
             $layout,
-            ['pagerFolder' => $pager, 'treeItems' => $treeItems]
+            array( 'pagerFolder' => $pager, 'treeItems' => $treeItems ) + $params
         );
     }
 }

--- a/Controller/FolderController.php
+++ b/Controller/FolderController.php
@@ -29,18 +29,13 @@ class FolderController extends Controller
      * @throws NotFoundHttpException $location is flagged as invisible
      * @return \Symfony\Component\HttpFoundation\Response
      */
-    public function showFolderListAsideViewAction( Location $location )
+    public function showFolderListAsideViewAction( Location $location, $viewType, $layout = false )
     {
-        $response = new Response();
 
         if ( $location->invisible )
         {
             throw new NotFoundHttpException( "Location #$location->id cannot be displayed as it is flagged as invisible." );
         }
-
-        $response->setSharedMaxAge( $this->getConfigResolver()->getParameter( 'content.default_ttl' ) );
-        $response->headers->set( 'X-Location-Id', $location->id );
-        $response->setVary( 'X-User-Hash' );
 
         $languages = $this->getConfigResolver()->getParameter( 'languages' );
 
@@ -66,12 +61,18 @@ class FolderController extends Controller
             $treeChildItems[] = $hit->valueObject;
         }
 
-        return $this->get( 'ez_content' )->viewLocation(
+        $response = $this->get( 'ez_content' )->viewLocation(
             $location->id,
-            'aside_sub',
-            true,
+            $viewType,
+            $layout,
             ['treeChildItems' => $treeChildItems]
         );
+
+        $response->setSharedMaxAge( $this->getConfigResolver()->getParameter( 'content.default_ttl' ) );
+        $response->headers->set( 'X-Location-Id', $location->id );
+        $response->setVary( 'X-User-Hash' );
+
+        return $response;
     }
 
     /**
@@ -82,18 +83,12 @@ class FolderController extends Controller
      * @throws NotFoundHttpException $location is flagged as invisible
      * @return \Symfony\Component\HttpFoundation\Response
      */
-    public function showFolderListAction( Request $request, Location $location )
+    public function showFolderListAction( Request $request, Location $location, $viewType, $layout = false )
     {
-        $response = new Response();
-
         if ( $location->invisible )
         {
             throw new NotFoundHttpException( "Location #$location->id cannot be displayed as it is flagged as invisible." );
         }
-
-        $response->setSharedMaxAge( $this->getConfigResolver()->getParameter( 'content.default_ttl' ) );
-        $response->headers->set( 'X-Location-Id', $location->id );
-        $response->setVary( 'X-User-Hash' );
 
         $content = $this->getRepository()
             ->getContentService()
@@ -147,11 +142,17 @@ class FolderController extends Controller
             $treeItems[] = $hit->valueObject;
         }
 
-        return $this->get( 'ez_content' )->viewLocation(
+        $response = $this->get( 'ez_content' )->viewLocation(
             $location->id,
-            'full',
-            true,
+            $viewType,
+            $layout,
             ['pagerFolder' => $pager, 'treeItems' => $treeItems]
         );
+
+        $response->setSharedMaxAge( $this->getConfigResolver()->getParameter( 'content.default_ttl' ) );
+        $response->headers->set( 'X-Location-Id', $location->id );
+        $response->setVary( 'X-User-Hash' );
+
+        return $response;
     }
 }

--- a/Controller/FolderController.php
+++ b/Controller/FolderController.php
@@ -17,7 +17,6 @@ use eZ\Publish\Core\Pagination\Pagerfanta\ContentSearchAdapter;
 use eZ\Bundle\EzPublishCoreBundle\Controller;
 use Pagerfanta\Pagerfanta;
 use Symfony\Component\HttpFoundation\Response;
-use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 use Symfony\Component\HttpFoundation\Request;
 
 class FolderController extends Controller
@@ -26,7 +25,6 @@ class FolderController extends Controller
      * Displays the sub folder if it exists
      *
      * @param \eZ\Publish\API\Repository\Values\Content\Location $location of a folder
-     * @throws NotFoundHttpException $location is flagged as invisible
      * @return \Symfony\Component\HttpFoundation\Response
      */
     public function showFolderListAsideViewAction( Location $location, $viewType, $layout = false, array $params = array() )
@@ -68,7 +66,6 @@ class FolderController extends Controller
      *
      * @param \eZ\Publish\API\Repository\Values\Content\Location $location of a folder
      * @param \Symfony\Component\HttpFoundation\Request $request request object
-     * @throws NotFoundHttpException $location is flagged as invisible
      * @return \Symfony\Component\HttpFoundation\Response
      */
     public function showFolderListAction( Request $request, Location $location, $viewType, $layout = false, array $params = array() )

--- a/Controller/FolderController.php
+++ b/Controller/FolderController.php
@@ -31,7 +31,6 @@ class FolderController extends Controller
      */
     public function showFolderListAsideViewAction( Location $location, $viewType, $layout = false )
     {
-
         if ( $location->invisible )
         {
             throw new NotFoundHttpException( "Location #$location->id cannot be displayed as it is flagged as invisible." );

--- a/Controller/FolderController.php
+++ b/Controller/FolderController.php
@@ -31,11 +31,6 @@ class FolderController extends Controller
      */
     public function showFolderListAsideViewAction( Location $location, $viewType, $layout = false, array $params = array() )
     {
-        if ( $location->invisible )
-        {
-            throw new NotFoundHttpException( "Location #$location->id cannot be displayed as it is flagged as invisible." );
-        }
-
         $languages = $this->getConfigResolver()->getParameter( 'languages' );
 
         $includedContentTypeIdentifiers = $this->container->getParameter( 'ezdemo.folder.folder_tree.included_content_types' );
@@ -78,11 +73,6 @@ class FolderController extends Controller
      */
     public function showFolderListAction( Request $request, Location $location, $viewType, $layout = false, array $params = array() )
     {
-        if ( $location->invisible )
-        {
-            throw new NotFoundHttpException( "Location #$location->id cannot be displayed as it is flagged as invisible." );
-        }
-
         $content = $this->getRepository()
             ->getContentService()
             ->loadContentByContentInfo( $location->getContentInfo() );

--- a/Controller/FolderController.php
+++ b/Controller/FolderController.php
@@ -61,18 +61,12 @@ class FolderController extends Controller
             $treeChildItems[] = $hit->valueObject;
         }
 
-        $response = $this->get( 'ez_content' )->viewLocation(
+        return $this->get( 'ez_content' )->viewLocation(
             $location->id,
             $viewType,
             $layout,
             ['treeChildItems' => $treeChildItems]
         );
-
-        $response->setSharedMaxAge( $this->getConfigResolver()->getParameter( 'content.default_ttl' ) );
-        $response->headers->set( 'X-Location-Id', $location->id );
-        $response->setVary( 'X-User-Hash' );
-
-        return $response;
     }
 
     /**
@@ -142,17 +136,11 @@ class FolderController extends Controller
             $treeItems[] = $hit->valueObject;
         }
 
-        $response = $this->get( 'ez_content' )->viewLocation(
+        return $this->get( 'ez_content' )->viewLocation(
             $location->id,
             $viewType,
             $layout,
             ['pagerFolder' => $pager, 'treeItems' => $treeItems]
         );
-
-        $response->setSharedMaxAge( $this->getConfigResolver()->getParameter( 'content.default_ttl' ) );
-        $response->headers->set( 'X-Location-Id', $location->id );
-        $response->setVary( 'X-User-Hash' );
-
-        return $response;
     }
 }

--- a/Resources/views/full/folder.html.twig
+++ b/Resources/views/full/folder.html.twig
@@ -1,4 +1,4 @@
-{% extends "eZDemoBundle::pagelayout.html.twig" %}
+{% extends noLayout ? viewbaseLayout : "eZDemoBundle::pagelayout.html.twig" %}
 
 {% block content %}
     <section class="content-view-full">


### PR DESCRIPTION
The response from viewLocation should be used as the the response created is not used.  This also adds support for different view types.