### PR TITLE
Fix for EZP-24015: Improve Language Switcher flags and logic

### DIFF
--- a/Resources/views/parts/languages_switcher.html.twig
+++ b/Resources/views/parts/languages_switcher.html.twig
@@ -11,7 +11,7 @@
 
             {% for lang in availableLanguages %}
                 {% do routeRef.set( "siteaccess", ezpublish.translationSiteAccess( lang ) ) %}
-                    {% if lang == currentLang %}
+                    {% if lang == currentLanguage %}
                         <li class="current">
                             <span class="flag-icon flag-icon-background flag-icon-{{ lang[4:]|lower }}"></span>{{ lang[:3]|lower|capitalize }}
                         </li>


### PR DESCRIPTION
### Fix for EZP-24015: Improve Language Switcher flags and logic

After the [EZP-24015: Improve Language Switcher flags and logic](https://github.com/ezsystems/DemoBundle/pull/141/files) a typo has been introduced, instead of currentLanguage it was currentLang.