### PR TITLE
Fix: EZP-24477 Some main menu items dissapear when you're logged

### DIFF
--- a/Menu/Builder.php
+++ b/Menu/Builder.php
@@ -142,6 +142,7 @@ class Builder
             )
         );
         $query->sortClauses = array( new Query\SortClause\Location\Path() );
+        $query->limit = 25;
         $query->performCount = false;
 
         return $this->searchService->findLocations( $query )->searchHits;


### PR DESCRIPTION
Fixes https://jira.ez.no/browse/EZP-24477, https://jira.ez.no/browse/EZP-24413

By default ```$query->limit``` is 10, so if you don't raise that, the query only returns the 10 first elements it finds in first and second level. 
That's because two last main menu items are missing.

In this patch, I raise the limit to 25. But how could we build a query without limit? i mean, a query that will return all the elements without the need to set $query->limit?

ping @andrerom @bdunogier @clash82 