### PR TITLE
Fix EZP-24478: Partner page can't be seen without legacy enabled

### DIFF
--- a/Features/Content/partner.feature
+++ b/Features/Content/partner.feature
@@ -1,0 +1,23 @@
+Feature: Partner
+    Scenario: A visitor can't see "Partner" in the main menu
+        Given I am not logged in
+         Then on "main navigation" I shouldn't see links:
+             | Partner |
+
+    Scenario: A visitor can't access "Partner" page
+        Given I am not logged in
+        Given I am on the homepage
+         When I go to "partner" page
+         Then I see "Login" text
+
+    Scenario: As administrator, I can see "Partner" in the main menu
+        Given I am logged as an "administrator"
+        Given I am on the "home" page
+         Then on "main navigation" I see links:
+             | Partner |
+
+    Scenario: As administrator, I can see Partner page
+        Given I am logged as an "administrator"
+        Given I am on the "partner" page
+         Then I see "eZ Logo Black" text
+          And I see "eZ Logo White" text

--- a/Features/Context/Content/Context.php
+++ b/Features/Context/Content/Context.php
@@ -37,6 +37,7 @@ class Context extends Demo
         $this->mainAttributes += array(
             "ez logo" => array( "class" => "logo", "href" => "/" ),
             "main content" => array( "class" => "main-content" ),
+            "main navigation" => array( "class" => "main-navi" ),
         );
     }
 

--- a/Features/Context/Demo.php
+++ b/Features/Context/Demo.php
@@ -33,7 +33,8 @@ class Demo extends Context
             "place" => "/eZ-Mountains",
             "services" => "/Shopping/Services",
             "products" => "/Shopping/Products",
-            "resources" => "/Getting-Started/Resources"
+            "resources" => "/Getting-Started/Resources",
+            "partner" => "/Partner",
         );
 
         $this->mainAttributes += array(

--- a/Resources/config/ezdemo.yml
+++ b/Resources/config/ezdemo.yml
@@ -100,6 +100,10 @@ system:
                     template: "eZDemoBundle:line:folder.html.twig"
                     match:
                         Identifier\ContentType: [folder]
+                file:
+                    template: "eZDemoBundle:line:file.html.twig"
+                    match:
+                        Identifier\ContentType: [file]
 
         content_view:
             embed:

--- a/Resources/views/line/file.html.twig
+++ b/Resources/views/line/file.html.twig
@@ -1,0 +1,22 @@
+{#
+    File line view
+#}
+
+<div class="content-view-line">
+    <div class="class-file">
+        <h2>{{ ez_content_name( content ) }}</h2>
+
+        <div class="attribute-short">
+            {{ ez_render_field( content, 'description' ) }}
+        </div>
+        <div class="break"></div>
+        <div class="attribute-file">
+            <p>{{ ez_render_field( content, 'file' ) }}</p>
+        </div>
+
+        <div class="attribute-link">
+            <p><a href={{ path( location ) }}>{{ 'Details'|trans }}</a></p>
+        </div>
+
+    </div>
+</div>


### PR DESCRIPTION
Fix https://jira.ez.no/browse/EZP-24478

Make possible to access and view Partner page without legacy stack enabled

It just ass a line view for files for it. 

Added also a feature for this page. 

Let me know if it's ok

ping @andrerom @miguelcleverti @joaoinacio @bdunogier 