### PR TITLE
Disable demo-clean option

### DIFF
--- a/Resources/config/services.yml
+++ b/Resources/config/services.yml
@@ -86,11 +86,12 @@ services:
             - @ezpublish.api.repository
             - %ezdemo.premium_content.role_id%
 
-    ezdemo.installer.democlean_installer:
-        parent: ezplatform.installer.db_based_installer
-        class: %ezdemo.installer.democlean_installer.class%
-        tags:
-            - {name: ezplatform.installer, type: demo-clean}
+    # Disabled as it is currently broken missing some data
+    #ezdemo.installer.democlean_installer:
+    #    parent: ezplatform.installer.db_based_installer
+    #    class: %ezdemo.installer.democlean_installer.class%
+    #    tags:
+    #        - {name: ezplatform.installer, type: demo-clean}
 
     ezdemo.installer.demo_installer:
         parent: ezplatform.installer.db_based_installer


### PR DESCRIPTION
ping @bdunogier 

heads up @lserwatka


demo-clean is missing ezcontentobject_name data, and maybe other things as well. This causes exception after recent kernel Legacy SE change to content loading sql to reduce high amounts of rows -> low perf -> high mem-use -> reaching mem limits.