### PR TITLE
Fix EZP-24897: Error on blog post first draft preview

### DIFF
--- a/Controller/DemoController.php
+++ b/Controller/DemoController.php
@@ -156,9 +156,20 @@ class DemoController extends Controller
      */
     public function showBlogPostAction( $locationId, $viewType, $layout = false, array $params = array() )
     {
-        // We need the author, whatever the view type is.
         $repository = $this->getRepository();
-        $location = $repository->getLocationService()->loadLocation( $locationId );
+        if ( isset( $params['location'] ) && $params['location'] instanceof Location )
+        {
+            $location = $params['location'];
+        }
+        else if ( is_numeric( $locationId ) )
+        {
+            $location = $repository->getLocationService()->loadLocation( $locationId );
+        }
+        else
+        {
+            throw new NotFoundHttpException( "Unknown location '$locationId' cannot be displayed." );
+        }
+        // We need the author, whatever the view type is.
         $author = $repository->getUserService()->loadUser( $location->getContentInfo()->ownerId );
 
         // TODO once the keyword service is available, load the number of keyword for each keyword


### PR DESCRIPTION
JIRA: https://jira.ez.no/browse/EZP-24897

Make sure not to attempt loading a `null` locationId when previewing a first draft.

(this has been resolved in master with the `@ParamConverter` in controllers)