### PR TITLE
Improved siteaccess configuration

### DIFF
--- a/Resources/config/ezdemo.yml
+++ b/Resources/config/ezdemo.yml
@@ -1,14 +1,3 @@
-siteaccess:
-    groups:
-        ezdemo_frontend_group:
-            - ezdemo_site
-            - ezdemo_site_user
-            - eng
-            - fre
-        language_switcher_group:
-            - eng
-            - fre
-
 system:
     default:
         user:
@@ -131,8 +120,3 @@ system:
 
         field_templates:
             - {template: "eZDemoBundle::content_fields.html.twig", priority: 10}
-
-    # Install the eng and fre translations to have a demo of the language switcher
-    language_switcher_group:
-        translation_siteaccesses: [fre, eng]
-

--- a/Resources/installer/config_templates/ezpublish.yml
+++ b/Resources/installer/config_templates/ezpublish.yml
@@ -21,10 +21,11 @@ ezpublish:
         # Available siteaccesses
         list:
             - demo_site
+            - fre
 
         # Siteaccess groups. Use them to group common settings.
         groups:
-            demo_site_group: [demo_site]
+            demo_site_group: [demo_site, fre]
         default_siteaccess: demo_site
         match:
             URIElement: 1
@@ -35,6 +36,7 @@ ezpublish:
     # System settings, grouped by siteaccess and/or siteaccess group
     system:
         demo_site_group:
+            translation_siteaccesses: [demo_site, fre]
             repository: demo_repository
             var_dir: var/ezdemo_site
             languages:


### PR DESCRIPTION
> Required by ezsystems/ezpublish-kernel#1425

Overall, defining the siteaccessess should be done at app level, not site bundle.

- Removed siteaccess groups config from `ezdemo.yml`
- Added siteacces config to install config `template.yml`