### PR TITLE
Applied the view controller refactoring

### DIFF
--- a/Controller/FeedbackFormController.php
+++ b/Controller/FeedbackFormController.php
@@ -9,7 +9,7 @@
 namespace EzSystems\DemoBundle\Controller;
 
 use eZ\Bundle\EzPublishCoreBundle\Controller;
-use eZ\Publish\API\Repository\Values\Content\Location;
+use eZ\Publish\Core\MVC\Symfony\View\ContentView;
 use EzSystems\DemoBundle\Entity\Feedback;
 use EzSystems\DemoBundle\Helper\EmailHelper;
 use Symfony\Component\HttpFoundation\Request;
@@ -17,17 +17,16 @@ use Symfony\Component\HttpFoundation\Request;
 class FeedbackFormController extends Controller
 {
     /**
-     * Displays and manages the feedback form.
+     * Displays the feedback form, and processes posted data.
+     * The signature of this method follows the one from the default view controller, and adds the Request, since
+     * we use to handle form data.
      *
-     * The signature of this method follows the one from the default view controller.
-     * @param \eZ\Publish\API\Repository\Values\Content\Location $location
-     * @param $viewType
-     * @param bool $layout
-     * @param array $params
+     * @param \Symfony\Component\HttpFoundation\Request $request
+     * @param \eZ\Publish\Core\MVC\Symfony\View\ContentView $view
      *
-     * @return mixed
+     * @return View
      */
-    public function showFeedbackFormAction(Request $request, Location $location, $viewType, $layout = false, array $params = array())
+    public function showFeedbackFormAction(Request $request, ContentView $view)
     {
         // Creating a form using Symfony's form component
         $feedback = new Feedback();
@@ -51,15 +50,12 @@ class FeedbackFormController extends Controller
                     $this->get('translator')->trans('Thank you for your message, we will get back to you as soon as possible.')
                 );
 
-                return $this->redirect($this->generateUrl($location));
+                return $this->redirect($this->generateUrl($view->getLocation()));
             }
         }
 
-        return $this->get('ez_content')->viewLocation(
-            $location->id,
-            $viewType,
-            $layout,
-            array('form' => $form->createView()) + $params
-        );
+        $view->addParameters(['form' => $form->createView()]);
+
+        return $view;
     }
 }

--- a/PremiumContent/PremiumLocationViewProvider.php
+++ b/PremiumContent/PremiumLocationViewProvider.php
@@ -9,13 +9,15 @@ namespace EzSystems\DemoBundle\PremiumContent;
 
 use eZ\Publish\API\Repository\Repository;
 use eZ\Publish\API\Repository\Values\Content\Location;
+use eZ\Publish\Core\MVC\Symfony\View\ContentValueView;
 use eZ\Publish\Core\MVC\Symfony\View\ContentView;
-use eZ\Publish\Core\MVC\Symfony\View\Provider\Location as LocationViewProvider;
+use eZ\Publish\Core\MVC\Symfony\View\View;
+use eZ\Publish\Core\MVC\Symfony\View\ViewProvider;
 
 /**
  * Returns the premium_content view if it applies to a location and if the user isn't a Premium subscriber.
  */
-class PremiumLocationViewProvider implements LocationViewProvider
+class PremiumLocationViewProvider implements ViewProvider
 {
     /**
      * ID of the section used to mark content as Premium.
@@ -38,13 +40,19 @@ class PremiumLocationViewProvider implements LocationViewProvider
         $this->subscriptionChecker = $subscriptionChecker;
     }
 
-    public function getView(Location $location, $viewType)
+    public function getView(View $view)
     {
+        $viewType = $view->getViewType();
+
         if ($viewType !== 'full') {
             return null;
         }
 
-        if ($location->getContentInfo()->sectionId !== $this->premiumSectionId) {
+        if (!$view instanceof ContentValueView) {
+            return null;
+        }
+
+        if ($view->getContent()->contentInfo->sectionId !== $this->premiumSectionId) {
             return null;
         }
 


### PR DESCRIPTION
This applies the changes from ezsystems/ezpublish-kernel#1454.

Content and Location controller actions now receive a `ContentView` object as their argument instead of individual parameters. The Content and Location objects are pre-loaded.

The actions can now return the View object, modified according to the needs of the controller, instead of building the Response.