### PR TITLE
EZP-25485 - eZ Demo with video block but no content will return error 500

### DIFF
--- a/Resources/views/block/video.html.twig
+++ b/Resources/views/block/video.html.twig
@@ -4,14 +4,16 @@
         <h2>{{ block.name }}</h2>
     </div>
     {% endif %}
-    {{ render(
-        controller(
-            "ez_content:viewLocation",
-            {
-                "locationId": valid_items[0].locationId,
-                "viewType": "block_item",
-                "params": {"block_id": block.id, "block_name": block.name}
-            }
-        )
-    ) }}
+    {% if valid_items[0] is defined %}
+        {{ render(
+            controller(
+                "ez_content:viewLocation",
+                {
+                    "locationId": valid_items[0].locationId,
+                    "viewType": "block_item",
+                    "params": {"block_id": block.id, "block_name": block.name}
+                }
+            )
+        ) }}
+    {% endif %}
 </div>


### PR DESCRIPTION
# EZP-25485 - eZ Demo with video block but no content will return error 500

If you add a video block to a landing page object, but don't add any content to the video block, when accessing the landing page it will return a

Link: https://jira.ez.no/browse/EZP-25485

````
Key "0" does not exist as the array is empty in eZDemoBundle:block:video.html.twig at line 11
````