### PR TITLE
EZEE-1483: Limit Twig to 1.x due to invalid constraint in KnpMenuBundle 1.x which breaks with Twig 2.x

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,6 +16,7 @@
         "ezsystems/platform-ui-assets-bundle": "~1.0@dev",
         "whiteoctober/breadcrumbs-bundle": "~1.0.1",
         "knplabs/knp-menu-bundle": "1.*",
+        "twig/twig": "~1.28",
         "zetacomponents/feed": "~1.4",
         "ezsystems/demobundle-data": "~1.0@dev",
         "components/bootstrap": "3.3.2",


### PR DESCRIPTION
**JIRA: https://jira.ez.no/browse/EZEE-1483**

This PR has no real impact as DemoBundle is no longer maintained. Although DemoBundle is affected by invalid version constraint for `twig/twig` in `knplabs/knp-menu-bundle` package. This fix forces Twig 1.x to install.