### PR TITLE
EZP-29144: Website Toolbar cache doesn't work properly when Owner ( Self ) Policy Limitation is used

### DIFF
--- a/Resources/views/pagelayout.html.twig
+++ b/Resources/views/pagelayout.html.twig
@@ -21,7 +21,7 @@
 {% endif %}
 
 <!-- Complete page area: START -->
-    {{ render( controller( "ezpublish_legacy.website_toolbar.controller:websiteToolbarAction", { 'locationId': currentLocation.id|default( null )} ) ) }}
+    {{ render_esi( controller( "ezpublish_legacy.website_toolbar.controller:websiteToolbarAction", { 'locationId': currentLocation.id|default( null )} ) ) }}
 <div id="page" class="">
     <!-- Header area: START -->
     {% block header %}


### PR DESCRIPTION
JIRA issue: [EZP-29144](https://jira.ez.no/browse/EZP-29144)

Excerpt from JIRA:

> Currently, the cache related to Website Toolbar doesn't take into the account if someone is an owner of the viewed Content Object. This means that if someone who doesn't have content/edit permissions access views this Content Object first, then the owner won't have an option to edit that Content Object using Website Toolbar.

This PR fixes the issue in the Symfony stack by loading the Website Toolbar using ESI, so that it won't be cached alongside the rest of the page content ("Vary: X-User-Hash" is used there, which is wrong when we need to deal with Owner ( Self ) Policy Limitation).

PR for the kernel/Legacy Bridge which will make websiteToolbarAction's Response cacheable with "Vary: Cookie": https://github.com/ezsystems/LegacyBridge/pull/152