### PR TITLE
Follow-up EZP-29144: Pass semanticPathInfo as a controller argument

### DIFF
--- a/Resources/views/pagelayout.html.twig
+++ b/Resources/views/pagelayout.html.twig
@@ -21,7 +21,15 @@
 {% endif %}
 
 <!-- Complete page area: START -->
-    {{ render_esi( controller( "ezpublish_legacy.website_toolbar.controller:websiteToolbarAction", { 'locationId': currentLocation.id|default( null )} ) ) }}
+    {{ render_esi(
+        controller(
+            "ezpublish_legacy.website_toolbar.controller:websiteToolbarAction",
+            {
+                'locationId': currentLocation.id|default( null ),
+                'originalSemanticPathInfo': ezpublish.requestedUriString
+            }
+        )
+    ) }}
 <div id="page" class="">
     <!-- Header area: START -->
     {% block header %}


### PR DESCRIPTION
| Question           | Answer
| ------------------ | ------------------
| **JIRA issue**     | [EZP-29144](https://jira.ez.no/browse/EZP-29144)
| **Bug/Improvement**| yes
| **New feature**    | no
| **Target version** | `5.4`
| **BC breaks**      | no
| **Doc needed**     | yes (?)

Changes introduced in kernel made WebsiteToolbar loaded by ESI. Due to that fact, `$request->attributes->get('semanticPathInfo')` returned  `/_fragment` in all cases. This PR fixes this behavior by explicit passing `semanticPathInfo` as a controller parameter. 

